### PR TITLE
Add Nside and pixel index validity checks

### DIFF
--- a/test/healpix.jl
+++ b/test/healpix.jl
@@ -90,5 +90,19 @@ module Healpix
         @test all(issouthequbelt.(4, hpix4_pix) .== hpix4_issouthequbelt)
     end
 
+    @testset "Validity checks" begin
+        @test all(ishealpixok.(2.^(0:29)) .== true)
+        @test all(ishealpixok.([0, 2^30]) .== false)
+        @test_throws InvalidNside checkhealpix(0)
+
+        @test all(ishealpixok.(4, hpix4_pix) .== true)
+        @test all(ishealpixok.(4, [-1, 192]) .== false)
+        @test_throws InvalidPixel checkhealpix(4, 192)
+
+        for pix2fn in (pix2z, pix2theta, pix2phi, pix2ang, pix2vec)
+            @test_throws InvalidNside pix2fn(5,  0)
+            @test_throws InvalidPixel pix2fn(4, -1)
+        end
+    end
 end
 


### PR DESCRIPTION
Since HEALPix has a well-defined structure for valid Nside and pixel index values, we should be checking these.

The low(er)-level `is*` and `npix2*` functions have not had validity checks; this is motivated by the fact that the ring calculations make use of constructs like `nside2npixcap(3)` which would normally validate as bad even though the number it returns is exactly what we want.

TODO:
- [x] Add relevant documentation
- (Long term) Ellide cost of rechecking in dot-fusion operations (if compiler improvements don't get there first)