### PR TITLE
Improve Legendre computation interface

### DIFF
--- a/src/legendre.jl
+++ b/src/legendre.jl
@@ -303,7 +303,7 @@ end
 _chkbounds_Pl(norm::LegendreNormCoeff{N,T}, l::Integer, x::T
         ) where {N<:AbstractLegendreNorm, T<:Real}
     (0 ≤ l) || throw(DomainError())
-    (l ≤ length(norm.μ)) || throw(BoundsError())
+    (l < length(norm.μ)) || throw(BoundsError())
 end
 @noinline function
 _chkbounds_Plm(norm::N, l::Integer, m::Integer, x::T
@@ -314,7 +314,7 @@ end
 _chkbounds_Plm(norm::LegendreNormCoeff{N,T}, l::Integer, m::Integer, x::T
         ) where {N<:AbstractLegendreNorm, T<:Real}
     (0 ≤ l && 0 ≤ m ≤ l) || throw(DomainError())
-    (l ≤ length(norm.μ)) || throw(BoundsError())
+    (l < length(norm.μ)) || throw(BoundsError())
 end
 
 @noinline function
@@ -327,7 +327,7 @@ end
 _chkbounds_Pl!(norm::LegendreNormCoeff{N,T}, Λ::AbstractVector{T}, lmax::Integer,
         m::Integer, x::T) where {N<:AbstractLegendreNorm, T<:Real}
     (0 ≤ lmax && 0 ≤ m ≤ lmax) || throw(DomainError())
-    (lmax ≤ length(norm.μ)) || throw(BoundsError())
+    (lmax < length(norm.μ)) || throw(BoundsError())
     (size(Λ,1)≥lmax+1) || throw(DimensionMismatch())
 end
 
@@ -341,7 +341,7 @@ end
 _chkbounds_Plm!(norm::LegendreNormCoeff{N,T}, Λ::AbstractMatrix{T}, lmax::Integer,
         x::T) where {N<:AbstractLegendreNorm, T<:Real}
     (0 ≤ lmax) || throw(DomainError())
-    (lmax ≤ length(norm.μ)) || throw(BoundsError())
+    (lmax < length(norm.μ)) || throw(BoundsError())
     (size(Λ,1)≥lmax+1 && size(Λ,2)≥lmax+1) || throw(DimensionMismatch())
 end
 

--- a/src/legendre.jl
+++ b/src/legendre.jl
@@ -375,7 +375,7 @@ function legendre(norm::N, l::Integer, x::T
 end
 
 """
-    legendre!(norm::AbstractLegendreNorm, Λ::AbstractVecotr, lmax::Integer, m::Integer,
+    legendre!(norm::AbstractLegendreNorm, Λ::AbstractVector, lmax::Integer, m::Integer,
               x::Real)
 
 Fills the vector `Λ` with the pre-normalized Legendre polynomial values ``N_ℓ^m P_ℓ^m(x)``
@@ -502,6 +502,23 @@ function legendre!(norm::N, Λ::AbstractMatrix{T}, lmax::Integer, x::T
         return Λ
     end
 end
+
+# Make coefficient cache objects callable with similar syntax as the legendre[!] functions
+@propagate_inbounds function (norm::LegendreNormCoeff)(l::Integer, x::Real)
+    return legendre(norm, l, x)
+end
+@propagate_inbounds function (norm::LegendreNormCoeff)(l::Integer, m::Integer, x::Real)
+    return legendre(norm, l, m, x)
+end
+@propagate_inbounds function (norm::LegendreNormCoeff)(Λ::AbstractVector{T}, m::Integer, x::T) where T
+    lmax = length(norm.μ) - 1
+    return legendre!(norm, Λ, lmax, m, x)
+end
+@propagate_inbounds function (norm::LegendreNormCoeff)(Λ::AbstractMatrix{T}, x::T) where T
+    lmax = length(norm.μ) - 1
+    return legendre!(norm, Λ, lmax, x)
+end
+
 
 """
     p = Pl(l::Integer, x::Real)

--- a/src/pixelcovariance.jl
+++ b/src/pixelcovariance.jl
@@ -48,7 +48,7 @@ struct PixelCovarianceCoeff{T<:Real}
     function PixelCovarianceCoeff{T}(lmax::Integer) where T
         lmax = max(lmax, 2)
 
-        λ = LegendreUnitCoeff{T}(lmax)
+        λ = LegendreUnitCoeff{T}(lmax, 2)
         η = Vector{T}(lmax+1)
         α = Vector{T}(lmax+1)
         β = Vector{T}(lmax+1)

--- a/src/pixelcovariance.jl
+++ b/src/pixelcovariance.jl
@@ -95,6 +95,7 @@ function PixelCovarianceF!(C::PixelCovarianceCoeff{T}, F::AbstractMatrix{T},
     # this implementation. (Probably related to the keyword-argument penalty?)
     local ≈(x::T, y::T) where {T} = @fastmath x==y || abs(x-y) < eps(one(T))
 
+    λ! = C.λ
     half = inv(convert(T, 2))
 
     @inbounds begin
@@ -135,8 +136,7 @@ function PixelCovarianceF!(C::PixelCovarianceCoeff{T}, F::AbstractMatrix{T},
             end
 
             # Fill with P^0_ℓ(x) terms
-            legendre!(C.λ, P, lmax, 0, x)
-
+            λ!(P, 0, x)
         else # abs(x) ≈ one(T)
         # Case where two points are not antipodes
 
@@ -144,7 +144,7 @@ function PixelCovarianceF!(C::PixelCovarianceCoeff{T}, F::AbstractMatrix{T},
             xy = x * y
 
             # Fill with the P^2_ℓ(x) terms initially
-            legendre!(C.λ, P, lmax, 2, x)
+            λ!(P, 2, x)
 
             for ll=2:lmax
                 lT = convert(T, ll)
@@ -157,7 +157,7 @@ function PixelCovarianceF!(C::PixelCovarianceCoeff{T}, F::AbstractMatrix{T},
             end
 
             # Now refill P with the P^0_ℓ(x) terms
-            legendre!(C.λ, P, lmax, 0, x)
+            λ!(P, 0, x)
 
             # Compute the F10 terms with the P as is
             for ll=2:lmax

--- a/test/legendre.jl
+++ b/test/legendre.jl
@@ -27,17 +27,24 @@ module Legendre
         @test_throws DimensionMismatch legendre!(ctab, Λ₂, LMAX, 0.5)
     end
 
-    srand(2222)
-
-    # In general, all analytically-defined answers are computed using
-    # extended-precision ("big") floats and ints. This provides *some* testing
-    # for numerical accuracy, but explicit tests of numerical accuracy should
-    # probably also be defined.
-
+    @testset "Functor interface" begin
+        LMAX = 10
+        leg = LegendreSphereCoeff{Float64}(LMAX)
+        λ₁ = fill(0.0, LMAX+1)
+        λ₂ = fill(0.0, LMAX+1)
+        Λ₁ = fill(0.0, LMAX+1, LMAX+1)
+        Λ₂ = fill(0.0, LMAX+1, LMAX+1)
+        @test leg(1, 1, 0.5) == legendre(leg, 1, 1, 0.5)
+        @test leg(1, 0.5) == legendre(leg, 1, 0.5)
+        @test all(leg(λ₁, 2, 0.5) .== legendre!(leg, λ₂, LMAX, 2, 0.5))
+        @test all(leg(Λ₁, 0.5) .== legendre!(leg, Λ₂, LMAX, 0.5))
+    end
 
     #######################
     # LEGENDRE POLYNOMIALS
     #######################
+
+    srand(2222)
 
     # P_0 is a constant. Verify the output is invariant.
     @testset "Constant P_0 ($T)" for T in NumTypes

--- a/test/legendre.jl
+++ b/test/legendre.jl
@@ -3,6 +3,30 @@ module Legendre
     using ..CMBTests: NumTypes
     using CMB.Legendre
 
+    @testset "Domain and bounds checking" begin
+        LMAX = 10
+        ctab = LegendreUnitCoeff{Float64}(LMAX)
+
+        # Mathematical domain errors:
+        @test_throws DomainError Plm(-1, 0, 0.5)
+        @test_throws DomainError Plm(LMAX, -1, 0.5)
+        @test_throws DomainError Plm(LMAX, LMAX+1, 0.5)
+        @test_throws DomainError legendre(ctab, -1, 0, 0.5)
+        @test_throws DomainError legendre(ctab, LMAX, -1, 0.5)
+        @test_throws DomainError legendre(ctab, LMAX, LMAX+1, 0.5)
+
+        # Bounds error for precomputed coefficient tables
+        @test_throws BoundsError legendre(ctab, LMAX+1, 0, 0.5)
+
+        # Bounds error for filling vector or matrix
+        λ = Vector{Float64}(LMAX)
+        Λ₁ = Matrix{Float64}(LMAX, LMAX+1)
+        Λ₂ = Matrix{Float64}(LMAX+1, LMAX)
+        @test_throws DimensionMismatch legendre!(ctab, λ, LMAX, 0, 0.5)
+        @test_throws DimensionMismatch legendre!(ctab, Λ₁, LMAX, 0.5)
+        @test_throws DimensionMismatch legendre!(ctab, Λ₂, LMAX, 0.5)
+    end
+
     srand(2222)
 
     # In general, all analytically-defined answers are computed using


### PR DESCRIPTION
The `legendre` and `legendre!` function interfaces are more complicated than they strictly need to be in most circumstances. For cases where the coefficient lmax is appropriate, we can simplify the calls by removing both the coefficient and lmax arguments.

In the process of preparing this, I discovered a minor errors in bounds checking, so the bug fix and regressions tests for that are included as well.

Fixes #5.