### PR TITLE
Tweak Travis CI settings and coverage submission

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,27 +1,33 @@
 ## Documentation: http://docs.travis-ci.com/user/languages/julia/
 language: julia
+
 os:
   - linux
   - osx
+
 julia:
   - 0.6
   - nightly
+
 notifications:
   email: false
+
+# https://github.com/travis-ci/travis-ci/issues/4942 workaround
 git:
   depth: 99999999
 
-## uncomment the following lines to allow failures on nightly julia
-## (tests will run but not make your overall status red)
 matrix:
+  fast_finish: true
   allow_failures:
   - julia: nightly
 
 ## uncomment the following lines to override the default test script
-script:
-  - julia --check-bounds=yes -e 'Pkg.clone(pwd()); Pkg.build("CMB"); Pkg.test("CMB"; coverage=true)'
+#script:
+#  - julia -e 'Pkg.clone(pwd())'
+#  - julia -e 'Pkg.build("CMB")'
+#  - if [ -f test/runtests.jl ]; then
+#      julia --check-bounds=yes -e 'Pkg.test("CMB"; coverage=true)'
+#    fi
+
 after_success:
-  # push coverage results to Coveralls
-  - julia -e 'cd(Pkg.dir("CMB")); Pkg.add("Coverage"); using Coverage; Coveralls.submit(Coveralls.process_folder())'
-  # push coverage results to Codecov
-  - julia -e 'cd(Pkg.dir("CMB")); Pkg.add("Coverage"); using Coverage; Codecov.submit(Codecov.process_folder())'
+  - julia -e 'cd(Pkg.dir("CMB", "test")); include("coverage.jl")'

--- a/test/coverage.jl
+++ b/test/coverage.jl
@@ -1,0 +1,12 @@
+# Only run non-nightlies on Linux
+get(ENV, "TRAVIS_OS_NAME", "")       == "linux"   || exit()
+get(ENV, "TRAVIS_JULIA_VERSION", "") == "nightly" && exit()
+
+Pkg.add("Coverage")
+using Coverage
+
+cd(joinpath(dirname(@__FILE__), "..")) do
+    #Coveralls.submit(Coveralls.process_folder())
+    Codecov.submit(Codecov.process_folder())
+end
+


### PR DESCRIPTION
* Skip submitting coverage reports for Julia nightlies and non-Linux builds.
* Move coverage submission to a julia script to simplify travis config.
* Use default julia testing script