### PR TITLE
Unify legendre implementation

### DIFF
--- a/src/legendre.jl
+++ b/src/legendre.jl
@@ -328,7 +328,7 @@ end
     N = ndims(Λ)
     T = promote_type(TΛ, TV)
     z = convert(T, x)
-    y = sqrt(one(T) - z*z)
+    y = @fastmath sqrt(one(T) - z*z)
 
     pm   = zero(T)
     pmp1 = Plm_00(norm, T)

--- a/src/legendre.jl
+++ b/src/legendre.jl
@@ -19,7 +19,7 @@ export legendre, legendre!
 # Specific computation functions
 export Pl, Pl!, Plm, Plm!, Nlm, λlm, λlm!
 
-import Base: @boundscheck, @propagate_inbounds, eltype
+import Base: @boundscheck, @propagate_inbounds, eltype, convert
 
 
 
@@ -92,9 +92,19 @@ struct LegendreNormCoeff{N<:AbstractLegendreNorm,T<:Real} <: AbstractLegendreNor
 
         return new(μ, ν, α, β)
     end
+
+    function LegendreNormCoeff{N,T1}(norm::LegendreNormCoeff{N,T2}) where {N,T1,T2}
+        return new(convert(Vector{T1}, norm.μ),
+                   convert(Vector{T1}, norm.ν),
+                   convert(Matrix{T1}, norm.α),
+                   convert(Matrix{T1}, norm.β))
+    end
 end
 
 LegendreNormCoeff{N,T}(lmax::Integer) where {N,T} = LegendreNormCoeff{N,T}(lmax, lmax)
+
+convert(::Type{LegendreNormCoeff{N,T}}, norm::LegendreNormCoeff{N}) where {N,T} =
+        LegendreNormCoeff{N,T}(norm)
 
 """
     LegendreUnitCoeff{T}

--- a/src/legendre.jl
+++ b/src/legendre.jl
@@ -176,17 +176,18 @@ where ``β_ℓ^m`` is appropriate for the choice of normalization `N`.
 """
 function Plm_β end
 
-@inline function
-Plm_00(::LegendreUnitNorm, ::Type{T}) where {T<:Real}
-    return one(T)
+@inline @generated function
+Plm_00(::LegendreUnitNorm, ::Type{T}) where T
+    :(return $(one(T)))
 end
 
-@inline function
-Plm_00(::LegendreSphereNorm, ::Type{T}) where {T<:Real}
+@inline @generated function
+Plm_00(::LegendreSphereNorm, ::Type{T}) where T
     # comparing this against
     #   convert(T, inv(sqrt(4*convert(BigFloat, π))))
     # shows that this is exact within Float64 precision
-    return convert(T, inv(sqrt(4π)))
+    Pl00 = inv(sqrt(4 * convert(T, π)))
+    return :(return $Pl00)
 end
 
 @inline function

--- a/test/legendre.jl
+++ b/test/legendre.jl
@@ -4,6 +4,15 @@ module Legendre
     using ..CMBTests: NumTypes
     using CMB.Legendre
 
+    @testset "Coefficient table conversion" begin
+        dtab = LegendreSphereCoeff{Float64}(10)
+        ftab = convert(LegendreSphereCoeff{Float32}, dtab)
+
+        @test ftab isa LegendreSphereCoeff{Float32}
+        @test ftab.α == Float32.(dtab.α)
+        @test_throws MethodError convert(LegendreUnitCoeff{Float64}, dtab)
+    end
+
     @testset "Setting mmax" begin
         LMAX = 10
         MMAX = 2

--- a/test/legendre.jl
+++ b/test/legendre.jl
@@ -87,6 +87,31 @@ module Legendre
         @test all(leg(Λ₁, 0.5) .== legendre!(leg, Λ₂, LMAX, LMAX, 0.5))
     end
 
+    @testset "Mixed types" begin
+        LMAX = 10
+        legb! = LegendreUnitCoeff{BigFloat}(LMAX)
+        legd! = LegendreUnitCoeff{Float64}(LMAX)
+        λb = Vector{BigFloat}(undef, LMAX+1)
+        λd = Vector{Float64}(undef, LMAX+1)
+        xb = big"0.5"
+        xd = 5e-1
+
+        # Same table and array, mixed value
+        @test @inferred(legb!(λb, 2, xd)) isa typeof(λb)
+        @test @inferred(legd!(λd, 2, xb)) isa typeof(λd)
+
+        # Same table and value, mixed array
+        @test @inferred(legb!(λd, 2, xb)) isa typeof(λd)
+        @test @inferred(legd!(λb, 2, xd)) isa typeof(λb)
+
+        # Same array and value, mixed table
+        @test @inferred(legb!(λd, 2, xd)) isa typeof(λd)
+        @test @inferred(legd!(λb, 2, xb)) isa typeof(λb)
+
+        # All three mixed
+        @test @inferred(legb!(λd, 2, Float32(xd))) isa typeof(λd)
+    end
+
     @testset "Equality of legendre[!]" begin
         LMAX = 10
         x = 0.5


### PR DESCRIPTION
This simplifies the implementation of `legendre[!]` from having essentially 3 separate implementations (scalar, vector, and matrix) by combining all three into a single function — the compiler should be constant folding away the extra branches for the different sized outputs.

Simultaneously after this implementation consolidation, this allows me to make the entire function chain far more type agnostic, freeing us up to having mixed-type inputs and outputs actually work.