### PR TITLE
Simplify sphere implementations and increase test coverage

### DIFF
--- a/test/sphere.jl
+++ b/test/sphere.jl
@@ -1,6 +1,6 @@
 module Sphere
 using Test
-using LinearAlgebra, StaticArrays
+using LinearAlgebra, Random, StaticArrays
 using ..CMBTests: NumTypes
 using CMB.Sphere
 import CMB.Sphere: cart, ẑ
@@ -46,6 +46,48 @@ end
         @test @inferred(bearing2(   eqpnt..., npole...)) == (T( 1.0), T(0.0))
         @test @inferred(distance(   npole..., eqpnt...)) ≈ T(pi/2) atol=atol
         @test @inferred(cosdistance(npole..., eqpnt...)) ≈ T(0.0)  atol=atol
+    end
+end
+
+# Pairs of points on the equator will always have bearing angles of 90°, and
+# the angular separation is equal to the difference in azimuths.
+@testset "Points around equator ($T)" for T in NumTypes
+    local pi = T===BigFloat ? T(π) : 1.0π
+    atol = max(eps(1π), eps(T(π)))
+
+    Random.seed!(1928)
+    for nn in 1:4
+        θ  = T(pi / 2)
+        ϕ₁ = T(pi) * rand(T)
+        for Δϕ in T.((pi/8, pi/4, pi/2, 3pi/4, 7pi/8))
+            ϕ₂ = ϕ₁ + Δϕ
+            @test all((≈).(bearing2(θ, ϕ₁, θ, ϕ₂), T.((0, 1)), atol=atol))
+            @test all((≈).(bearing2(θ, ϕ₂, θ, ϕ₁), T.((0, 1)), atol=atol))
+            @test bearing( θ, ϕ₁, θ, ϕ₂) ≈ T(pi / 2) atol=atol
+            @test bearing( θ, ϕ₂, θ, ϕ₁) ≈ T(pi / 2) atol=atol
+            @test distance(θ, ϕ₁, θ, ϕ₂) ≈ Δϕ atol=atol
+            @test distance(θ, ϕ₂, θ, ϕ₁) ≈ Δϕ atol=atol
+        end
+    end
+end
+
+# For a pair of points on the same latitude and separated in azimuth by 180°, the
+# angular separation will be twice the colatitude angle.
+@testset "Isolatitudes ($T)" for T in NumTypes
+    local pi = T===BigFloat ? T(π) : 1.0π
+    # TODO: Figure out if there's a way to improve the situation so that this can be
+    #       dropped down to just max(eps) like the other test sets.
+    atol = sqrt(max(T(eps(1π)), eps(T(π))))
+
+    Random.seed!(4759)
+    for nn in 1:4
+        θ  = T(pi) * rand(T)
+        ϕ₁ = T(pi) * rand(T)
+        ϕ₂ = ϕ₁ + T(π)
+        σ  = θ > pi/2 ? T(2pi) - 2θ : 2θ
+
+        @test distance(θ, ϕ₁, θ, ϕ₂) ≈ σ atol=atol
+        @test distance(θ, ϕ₂, θ, ϕ₁) ≈ σ atol=atol
     end
 end
 

--- a/test/sphere.jl
+++ b/test/sphere.jl
@@ -1,86 +1,51 @@
 module Sphere
 using Test
-using LinearAlgebra
+using LinearAlgebra, StaticArrays
 using ..CMBTests: NumTypes
-using CMB.Sphere, StaticArrays
+using CMB.Sphere
+import CMB.Sphere: cart, ẑ
 
-@testset "Antipodes (angles, $T)" for T in NumTypes
-    npole = (T(0.0),  T(1.0))
-    spole = (T(π), T(2.0))
-
-    # North and South Pole antipodes
-    @test @inferred bearing(    npole..., spole...) == T(0.0)
-    @test @inferred bearing(    spole..., npole...) == T(0.0)
-    @test @inferred bearing2(   npole..., spole...) == (T(1.0), T(0.0))
-    @test @inferred bearing2(   spole..., npole...) == (T(1.0), T(0.0))
-    @test @inferred distance(   npole..., spole...) == T(π)
-    @test @inferred cosdistance(npole..., spole...) == T(-1.0)
-
-    # North and North Pole
-    @test @inferred bearing(    npole..., npole...) == T(0.0)
-    @test @inferred bearing2(   npole..., npole...) == (T(1.0), T(0.0))
-    @test @inferred distance(   npole..., npole...) == T(0.0)
-    @test @inferred cosdistance(npole..., npole...) == T(1.0)
-
-    # South and South Pole
-    @test @inferred bearing(    spole..., spole...) == T(0.0)
-    @test @inferred bearing2(   spole..., spole...) == (T(1.0), T(0.0))
-    @test @inferred distance(   spole..., spole...) == T(0.0)
-    @test @inferred cosdistance(spole..., spole...) == T(1.0)
-end
-
-@testset "Antipodes (vectors, $T)" for T in NumTypes
-    npole = @SVector T[0.0, 0.0,  1.0]
-    spole = @SVector T[0.0, 0.0, -1.0]
+@testset "Antipodes ($T)" for T in NumTypes
+    npole = SVector{3,T}(ẑ)
+    spole = SVector{3,T}(-ẑ)
 
     # North and South Pole antipodes
-    @test @inferred bearing(    npole, spole) == T(π)
-    @test @inferred bearing(    spole, npole) == T(π)
-    @test @inferred bearing2(   npole, spole) == (T(-1.0), T(0.0))
-    @test @inferred bearing2(   spole, npole) == (T(-1.0), T(0.0))
-    @test @inferred distance(   npole, spole) == T(π)
-    @test @inferred cosdistance(npole, spole) == T(-1.0)
+    @test @inferred(bearing(    npole, spole)) == T(π)
+    @test @inferred(bearing(    spole, npole)) == T(π)
+    @test @inferred(bearing2(   npole, spole)) == (T(-1.0), T(0.0))
+    @test @inferred(bearing2(   spole, npole)) == (T(-1.0), T(0.0))
+    @test @inferred(distance(   npole, spole)) == T(π)
+    @test @inferred(cosdistance(npole, spole)) == T(-1.0)
 
     # North and North Pole
-    @test @inferred bearing(    npole, npole) == T(0.0)
-    @test @inferred bearing2(   npole, npole) == (T(1.0), T(0.0))
-    @test @inferred distance(   npole, npole) == T(0.0)
-    @test @inferred cosdistance(npole, npole) == T(1.0)
+    @test @inferred(bearing(    npole, npole)) == T(0.0)
+    @test @inferred(bearing2(   npole, npole)) == (T(1.0), T(0.0))
+    @test @inferred(distance(   npole, npole)) == T(0.0)
+    @test @inferred(cosdistance(npole, npole)) == T(1.0)
 
     # South and South Pole
-    @test @inferred bearing(    spole, spole) == T(0.0)
-    @test @inferred bearing2(   spole, spole) == (T(1.0), T(0.0))
-    @test @inferred distance(   spole, spole) == T(0.0)
-    @test @inferred cosdistance(spole, spole) == T(1.0)
+    @test @inferred(bearing(    spole, spole)) == T(0.0)
+    @test @inferred(bearing2(   spole, spole)) == (T(1.0), T(0.0))
+    @test @inferred(distance(   spole, spole)) == T(0.0)
+    @test @inferred(cosdistance(spole, spole)) == T(1.0)
 end
 
-@testset "Pole to Equator (angles, $T)" for T in NumTypes
-    # Pole with arbitrary points around equator. Distance at the equator is easy to know
-    # analytically.
-    npole = (T(0.0), T(1.0))
+# Pole with arbitrary points around equator. Distance at the equator is easy to know
+# analytically, so vary longitudes to not nice multiples of π.
+@testset "Pole to Equator ($T)" for T in NumTypes
+    local pi = T===BigFloat ? T(π) : 1.0π
     atol = max(eps(1π), eps(T(π)))
+
+    # Use colatitude-azimuth pairs to test angle interfaces
+    npole = (T(0.0), T(0.0))
     for ii=1:7
-        local pi = T===BigFloat ? T(π) : 1.0π
         eqpnt = (T(pi/2), T(2pi*ii/7))
-        @test @inferred bearing(    npole..., eqpnt...) == T(0.0)
-        @test @inferred bearing2(   npole..., eqpnt...) == (T(1.0), T(0.0))
-        @test @inferred(distance(   npole..., eqpnt...)) ≈ T(π/2) atol=atol
-        @test @inferred(cosdistance(npole..., eqpnt...)) ≈ T(0.0) atol=atol
-    end
-end
-
-@testset "Pole to Equator (vectors, $T)" for T in NumTypes
-    # Pole with arbitrary points around equator. Distance at the equator is easy to know
-    # analytically, so vary longitudes to not nice multiples of π.
-    npole = @SVector T[0.0, 0.0, 1.0]
-    atol = max(eps(1π), eps(T(π)))
-    for ii=1:7
-        local pi = T===BigFloat ? T(π) : 1.0π
-        eqpnt = @SVector T[cos(2pi*ii/7), sin(2pi*ii/7), 0.0]
-        @test @inferred bearing(    npole, eqpnt) == T(pi)
-        @test @inferred bearing2(   npole, eqpnt) == (T(-1.0), T(0.0))
-        @test @inferred(distance(   npole, eqpnt)) ≈ T(π/2) atol=atol
-        @test @inferred(cosdistance(npole, eqpnt)) ≈ T(0.0) atol=atol
+        @test @inferred(bearing(    npole..., eqpnt...)) == T(pi)
+        @test @inferred(bearing(    eqpnt..., npole...)) == T(0.0)
+        @test @inferred(bearing2(   npole..., eqpnt...)) == (T(-1.0), T(0.0))
+        @test @inferred(bearing2(   eqpnt..., npole...)) == (T( 1.0), T(0.0))
+        @test @inferred(distance(   npole..., eqpnt...)) ≈ T(pi/2) atol=atol
+        @test @inferred(cosdistance(npole..., eqpnt...)) ≈ T(0.0)  atol=atol
     end
 end
 


### PR DESCRIPTION
Improve the quality of the sphere calculations.
- Eliminate the angle-based calculations in favor of internal conversion to the vector format. (Fixes #8)
- Add additional test cases that do not involve either of the poles and are not parallel vectors. This is required to fully exercise the full implementation of the bearing angle calculations.