### PR TITLE
Add tests calculating numerical derivatives

### DIFF
--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,4 +1,5 @@
 [deps]
+ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"

--- a/test/legendre.jl
+++ b/test/legendre.jl
@@ -271,6 +271,8 @@ module Legendre
         end
     end
 
+    # Test failed with world age problems when generated functions were incorrectly used;
+    # numerical derivative via newer world's Dual numbers tests for this error.
     @testset "Derivatives via dual numbers" begin
         using ForwardDiff: derivative
         LMAX = 5


### PR DESCRIPTION
The fixes applied in commits 54a8b18ed306 and 0f82b1a4cb77 were motivated by finding that ForwardDiff couldn't differentiate these functions due to world-age issues related to use of generated functions. These tests reproduce minimal cases to ensure a regression does not occur.