### PR TITLE
Vectorize Legendre calculations over multiple arguments

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,6 +1,6 @@
 using Documenter, CMB
 
-doctest = "--fix" in ARGS ? :fix : true
+doctest = "--fix" in ARGS ? :fix : false
 
 DocMeta.setdocmeta!(CMB, :DocTestSetup, :(using CMB); recursive=true)
 
@@ -9,7 +9,7 @@ makedocs(
     sitename = "CMB Analysis",
     authors = "Justin Willmert",
     modules = [CMB],
-    doctest = false,
+    doctest = doctest,
     doctestfilters = Regex[
         r"Ptr{0x[0-9a-f]+}",
         r"[0-9\.]+ seconds \(.*\)"

--- a/docs/src/man/legendre.md
+++ b/docs/src/man/legendre.md
@@ -78,7 +78,7 @@ mechanics and obeys the following properties:
 
 ### Calculating scalar values
 
-At the most basic, the associated Legendre polynomial ``P_ℓ^m(x)`` is computed by calling
+At its simplest, the associated Legendre polynomial ``P_ℓ^m(x)`` is computed by calling
 [`CMB.Legendre.Plm`](@ref). For example, to compute ``P_2^1(0.5)``,
 ```jldoctest PlmUsage
 julia> using CMB.Legendre
@@ -173,31 +173,29 @@ julia> λlm(157, 150, 0.5)
 ### Calculating all values up to a given ``ℓ_\mathrm{max}``
 
 Because calculating a particular Legendre polynomial value is the end result of running
-a recurrence relation, using Julia's dot broadcasting to compute ``P_ℓ^m(x)``
-for all ``ℓ`` is inefficient and redoes a lot of work:
+a recurrence relation, looping evaluation of ``P_ℓ^m(x)`` for all ``ℓ`` is inefficient and
+redoes a lot of work:
 ```jldoctest PlmUsage
 julia> λ = zeros(701);
 
-julia> @time λ[3:701] .= λlm.(2:700, 2, 0.5);
-  0.042107 seconds (4.61 k allocations: 257.940 KiB)
+julia> @time λ[3:701] = [λlm(l, 2, 0.5) for l in 2:700];
+  0.063346 seconds (56.42 k allocations: 2.539 MiB)
 ```
-It's far more efficient to incrementally calculate the ``ℓ+1`` term directly from the
-``ℓ`` term.
+It's far more efficient to accumulate the intermediate terms while running the recurrence
+relations.
 Both of `Plm` and `λlm` have modifying counterparts,
-[`Plm!`](@ref Plm!(::AbstractVector, ::Integer, ::Integer, ::Real)) and
-[`λlm!`](@ref λlm!(::AbstractVector, ::Integer, ::Integer, ::Real)) respectively,
+[`Plm!`](@ref Plm!(::Any, ::Integer, ::Integer, ::Any)) and
+[`λlm!`](@ref λlm!(::Any, ::Integer, ::Integer, ::Any)) respectively,
 which fill an appropriately sized vector for a specified ``ℓ_\mathrm{max}``.
 ```jldoctest PlmUsage
 julia> @time λlm!(λ, 700, 2, 0.5);
-  0.000036 seconds (4 allocations: 160 bytes)
+  0.000162 seconds (14 allocations: 320 bytes)
 ```
-On my machine, this ends up being roughly 1000 times faster!
+On my machine, this ends up being roughly 400 times faster!
 
 If all Legendre polynomial values for some ``x`` over all
-``ℓ ∈ [0,ℓ_\mathrm{max}]`` and ``m ∈ [0,ℓ]`` are required, there are also methods of
-[`Plm!`](@ref Plm!(::AbstractMatrix, ::Integer, ::Integer, ::Real)) and
-[`λlm!`](@ref λlm!(::AbstractMatrix, ::Integer, ::Integer, ::Real))
-which fill the entire [lower triangular] matrix of values:
+``ℓ ∈ [0,ℓ_\mathrm{max}]`` and ``m ∈ [0,ℓ]`` are required, instead supply an output
+matrix into which the lower triangle of values is filled:
 ```jldoctest PlmUsage
 julia> Λ = zeros(701, 701);
 
@@ -206,6 +204,71 @@ julia> λlm!(Λ, 700, 700, 0.5);
 julia> Λ[701,3] == λlm(700, 2, 0.5)   # N.B. 1-based indexing of the array!
 true
 ```
+
+### Broadcasting over multiple arguments
+
+The Legendre polynomials can be evaluated over multiple arguments ``x`` as well by
+using Julia's standard broadcasting syntax:
+```jldoctest PlmUsage
+julia> λlm.(2, 0, range(-1.0, 1.0, length=5))
+5-element Array{Float64,1}:
+  0.63078313050504
+ -0.07884789131313
+ -0.31539156525252
+ -0.07884789131313
+  0.63078313050504
+```
+Broadcasting has been specialized for calls to `Pl`, `Plm`, and `λlm` to avoid the
+overhead inherent in calling the scalar functions multiple times:
+```jldoctest PlmUsage
+julia> z = range(-1.0, 1.0, length=500);
+
+julia> @time [λlm(2, 0, i) for i in z];
+  0.054037 seconds (54.23 k allocations: 2.447 MiB)
+
+julia> @time λlm.(2, 0, z);
+  0.000032 seconds (13 allocations: 36.719 KiB)
+```
+In fact, the shape of `z` is preserved, so any matrix shape can be used:
+```jldoctest PlmUsage; setup=(using Random; Random.seed!(0))
+julia> λlm.(2, 0, rand(3,3,3))
+3×3×3 Array{Float64,3}:
+[:, :, 1] =
+  0.326489  -0.285639  -0.313698
+  0.46875   -0.241804  -0.310982
+ -0.289767  -0.276217  -0.191519
+
+[:, :, 2] =
+  0.580778   -0.251413   0.091097
+  0.0093121   0.468216  -0.00159624
+ -0.0402128  -0.288992   0.397937
+
+[:, :, 3] =
+  0.57083   -0.311711  -0.313631
+  0.242235  -0.197404  -0.247441
+ -0.107      0.242107  -0.311164
+```
+
+Obtaining the Legendre polynomials over multiple ``\ell`` and/or ``m`` values for many
+arguments can be done via broadcasting as well.
+The degree `l` must be a `UnitRange` starting at zero, and `m` may be either a
+scalar integer (to calculate all ``\ell`` for a fixed ``m``) or a `UnitRange`
+starting at zero as well.
+For example, to compute the ``P_\ell^0(z)`` and ``P_\ell^2(z)`` coefficients to an
+``\ell_{\mathrm{max}} = 700``, one could execute
+```jldoctest PlmUsage
+julia> summary(Plm.(0:700, 0:2, z))
+"500×701×3 Array{Float64,3}"
+```
+The output array will have between 0 and 2 more dimensions more than the dimensionality
+of the input arguments depending on the calling convention.
+For scalar values of `l` and `m`, the output will be the same shape as `z` with no
+extra trailing dimensions.
+If instead `l` is a `UnitRange`, the output dimensionality increases by one, and the
+trailing dimension runs over the degrees ``\ell``;
+switching to `m` a `UnitRange` as well, the output dimensionality is two greater than
+`z`, with the penultimate and final dimensions running over ``\ell`` and ``m``,
+respectively.
 
 ### Precomputed recursion factors
 
@@ -236,12 +299,15 @@ julia> coeff = LegendreSphereCoeff{Float64}(700);
 julia> legendre(coeff, 5, 2, 0.5)
 -0.15888479843070935
 ```
-On my machine, this results in a further ~50% decrease in computation time compared to
-`λlm!`:
-```jldoctest PlmUsage
-julia> @time legendre!(coeff, λ, 700, 2, 0.5);
-  0.000020 seconds
-```
+
+!!! warning "Performance Note"
+
+    Choosing whether to use the pre-computed coefficients or not should be guided by
+    benchmarking and performance profiling.
+    Modern processors can perform many floating point operations in the time it takes
+    to load the coefficients from memory, so depending on the complexity of the
+    normalization, you may actually achieve better performance by recomputing the
+    recursion coefficients on demand.
 
 Notice that due to its flexibility, `legendre!` requires explicit `lmax` and `mmax`
 arguments even though the `LegendreNormCoeff` has a `lmax` and `mmax` set during
@@ -406,7 +472,7 @@ julia> struct λNorm <: AbstractLegendreNorm end
 The initial condition is specified by providing a method of `Plm_00` which takes our
 normalization trait type as the first argument.
 (The second argument can be useful if some extra type information is required to set
-up a type-stable algorithm.)
+up a type-stable algorithm, which we'll ignore here for the sake of simplicity.)
 ```jldoctest λNorm
 julia> Plm_00(::λNorm, T::Type) = sqrt(1 / 4π)
 Plm_00 (generic function with 4 methods)

--- a/docs/src/man/legendre.md
+++ b/docs/src/man/legendre.md
@@ -139,7 +139,7 @@ julia> n = Nlm(BigFloat, 157, 150)
 4.14800666209481424285411223457923933542541063872695815968861285171699012214351e-314
 
 julia> p = Plm(157, 150, big"0.5")
-4.768286486602206390406601862422168575170463348990958242752608686436785229641202e+308
+4.768286486602206390406601862422168575170463348990958242752608686436785229641823e+308
 
 julia> Float64(n * p)
 1.9778884113202627e-5
@@ -161,7 +161,7 @@ defined as
 computing the normalization separately from the function:
 ```jldoctest PlmUsage
 julia> λlm(157, 150, 0.5)
-1.977888411320241e-5
+1.977888411320258e-5
 ```
 
 !!! note
@@ -438,12 +438,12 @@ With just those 5 methods provided, the full Legendre framework is available,
 including precomputing the coefficients.
 ```jldoctest λNorm
 julia> legendre(λNorm(), 700, 500, 0.4)
-0.35366224602810997
+0.35366224602811
 
 julia> coeff = LegendreNormCoeff{λNorm,Float64}(700);
 
 julia> legendre(coeff, 700, 500, 0.4)
-0.35366224602810997
+0.35366224602811
 ```
 
 ---

--- a/src/legendre.jl
+++ b/src/legendre.jl
@@ -141,7 +141,7 @@ function Base.show(io::IO, ::MIME"text/plain", N::LegendreNormCoeff)
 end
 
 """
-    Plm_00(::N, ::Type{T}) where {N<:AbstractLegendreNorm, T<:Real}
+    Plm_00(::N, ::Type{T}) where {N<:AbstractLegendreNorm, T}
 
 Returns the initial condition ``P_0^0(x)`` for the associated Legendre recursions based
 on the normalization choice `N` for numeric type `T`.
@@ -149,7 +149,7 @@ on the normalization choice `N` for numeric type `T`.
 function Plm_00 end
 
 """
-    Plm_μ(norm::N, ::Type{T}, l::Integer) where {N<:AbstractLegendreNorm, T<:Real}
+    Plm_μ(norm::N, ::Type{T}, l::Integer) where {N<:AbstractLegendreNorm, T}
 
 Returns the coefficient ``μ_ℓ`` for the single-term recursion relation
 ```math
@@ -160,7 +160,7 @@ where ``μ_ℓ`` is appropriate for the choice of normalization `N`.
 function Plm_μ end
 
 """
-    Plm_ν(norm::N, ::Type{T}, l::Integer) where {N<:AbstractLegendreNorm, T<:Real}
+    Plm_ν(norm::N, ::Type{T}, l::Integer) where {N<:AbstractLegendreNorm, T}
 
 Returns the coefficient ``ν_ℓ`` for the single-term recursion relation
 ```math
@@ -171,7 +171,7 @@ where ``ν_ℓ`` is appropriate for the choice of normalization `N`.
 function Plm_ν end
 
 """
-    Plm_α(norm::N, ::Type{T}, l::Integer, m::Integer) where {N<:AbstractLegendreNorm, T<:Real}
+    Plm_α(norm::N, ::Type{T}, l::Integer, m::Integer) where {N<:AbstractLegendreNorm, T}
 
 Returns the coefficient ``α_ℓ^m`` for the two-term recursion relation
 ```math
@@ -182,7 +182,7 @@ where ``α_ℓ^m`` is appropriate for the choice of normalization `N`.
 function Plm_α end
 
 """
-    Plm_β(norm::N, ::Type{T}, l::Integer, m::Integer) where {N<:AbstractLegendreNorm, T<:Real}
+    Plm_β(norm::N, ::Type{T}, l::Integer, m::Integer) where {N<:AbstractLegendreNorm, T}
 
 Returns the coefficient ``β_ℓ^m`` for the two-term recursion relation
 ```math

--- a/src/legendre.jl
+++ b/src/legendre.jl
@@ -112,7 +112,7 @@ convert(::Type{LegendreNormCoeff{N,T}}, norm::LegendreNormCoeff{N}) where {N,T} 
 Precomputed recursion relation coefficients for the standard unit
 normalization. Alias for `LegendreNormCoeff{LegendreUnitNorm,T}`.
 """
-LegendreUnitCoeff = LegendreNormCoeff{LegendreUnitNorm}
+LegendreUnitCoeff{T} = LegendreNormCoeff{LegendreUnitNorm,T}
 
 """
     LegendreSphereCoeff{T}
@@ -120,7 +120,7 @@ LegendreUnitCoeff = LegendreNormCoeff{LegendreUnitNorm}
 Table type of precomputed recursion relation coefficients for the spherical
 harmonic normalization. Alias for `LegendreNormCoeff{LegendreSphereNorm,T}`.
 """
-LegendreSphereCoeff = LegendreNormCoeff{LegendreSphereNorm}
+LegendreSphereCoeff{T} = LegendreNormCoeff{LegendreSphereNorm,T}
 
 # Define element types as a way to conveniently promote, even for the trait types.
 # Union{} will always lose out in type promotion.

--- a/test/legendre.jl
+++ b/test/legendre.jl
@@ -292,4 +292,13 @@ module Legendre
             @test num_deriv1(l, m, x) ≈ dual_deriv1_tab(l, m, x)
         end
     end
+
+    @testset "Broadcasting arguments" begin
+        LMAX = 5
+        ctab = LegendreSphereCoeff{Float64}(LMAX)
+        z = range(-1, 1, length=10)
+        @test [Pl(LMAX, x) for x in z] == Pl.(LMAX, z)
+        @test [Plm(LMAX, LMAX, x) for x in z] == Plm.(LMAX, LMAX, z)
+        @test [λlm(LMAX, LMAX, x) for x in z] == λlm.(LMAX, LMAX, z)
+    end
 end

--- a/test/legendre.jl
+++ b/test/legendre.jl
@@ -142,7 +142,9 @@ module Legendre
         @test Λ₁ == λlm!(Λ₂, LMAX, LMAX, x)
 
         # Test single columns
+        fill!(λ₂, 0.0)
         @test @view(Λ₁[:,2+1]) == leg!(λ₂, 2, x)
+        fill!(λ₂, 0.0)
         @test @view(Λ₁[:,2+1]) == λlm!(λ₂, LMAX, 2, x)
     end
 
@@ -300,5 +302,14 @@ module Legendre
         @test [Pl(LMAX, x) for x in z] == Pl.(LMAX, z)
         @test [Plm(LMAX, LMAX, x) for x in z] == Plm.(LMAX, LMAX, z)
         @test [λlm(LMAX, LMAX, x) for x in z] == λlm.(LMAX, LMAX, z)
+    end
+
+    @testset "Numerical stability (issue #11)" begin
+        x = sind(-57.5)
+        lmax = 3 * 720
+        Λ = λlm.(0:lmax, 0:lmax, x)
+        # The amplitude bound of 1.5 is a very rough limit --- simply checking for
+        # unbounded growth.
+        @test all(abs.(Λ[end,:]) .< 1.5)
     end
 end


### PR DESCRIPTION
Generalize the core routine that implements the Legendre polynomial recursions to support broadcasting over multiple inputs of arbitrary shapes. This appears to slow down the scalar case, but the performance is better if the function is evaluated for a large number of arguments.

This work pulls the broadcast over arguments into the inside of the loops over degree/order so that loading and/or calculating coefficients is shared among multiple calculations. Furthermore, the recursions should be be eligible for SIMD operations.

TODO:
- [x] Write tests for broadcasted scalar operations
- [x] Write tests for in-place multi-argument calls
- [x] Update Legendre inline function documentation
- [x] Update Legendre manual documentation