### PR TITLE
Add ang2pix and vec2pix implementations

### DIFF
--- a/docs/src/man/healpix.md
+++ b/docs/src/man/healpix.md
@@ -171,14 +171,22 @@ where the elements correspond to the typical ``(x, y, z)`` right-handed coordina
 the positive ``z``-axis passing through the North Pole and the positive ``x``-axis
 passing through the Prime Meridian.
 
-In reverse, converting an arbitrary spherical coordinate to a pixel index... *...TO BE
-IMPLEMENTED...*
+In reverse, converting an arbitrary spherical coordinate to a pixel index is
+accomplished via the [`CMB.Healpix.ang2pix`](@ref) and
+[`CMB.Healpix.vec2pix`](@ref) methods, respectively:
+```jldoctest healpix
+julia> ang2pix(nside, pix2ang(nside, 103)...)
+103
+
+julia> vec2pix(nside, pix2vec(nside, 103))
+103
+```
 
 ## Input validation and error handling
 
 As stated earlier, the `HEALPix` ``\Nside`` parameter takes on values which are powers of
 two and by convention of the official `HEALPix` [^1] source is limited to the range
-``1`` to ``2^29``.
+``1`` to ``2^{29}``.
 Validity of any `nside` parameter can be checked with the
 [`CMB.Healpix.ishealpixok`](@ref ishealpixok(::Any)) function.
 ```jldoctest healpix
@@ -191,8 +199,7 @@ julia> ishealpixok.((5, 2^30))
 Likewise, once given an ``\Nside`` value, the pixel indices are bounded in ``0`` to
 `nside2npix(nside) - 1`;
 the two-argument form of [`ishealpixok`](@ref ishealpixok(::Any,::Any)) returns
-whether a pixel is valid
-for the specified `nside` or not:
+whether a pixel is valid for the specified `nside` or not:
 ```jldoctest healpix
 julia> nside2npix(4)
 192

--- a/docs/src/man/references.md
+++ b/docs/src/man/references.md
@@ -38,6 +38,18 @@
       s = (i - N_\mathrm{side}) \operatorname{mod} 2 + 1
     ```
 
+  - Erratum: Equation 22 differs in signs from equations A2–A3, and neither could be made
+    to work. Instead, the implementation here is derived from the system of equations:
+    ```math
+      \begin{align*}
+        z_p(ϕ, k_p) &= \frac{2}{3} - \frac{2k_p}{3N_{\mathrm{side}}}
+            + \frac{8ϕ}{3π}
+        \\
+        z_m(ϕ, k_m) &= -\frac{2}{3} + \frac{2k_m}{3N_{\mathrm{side}}}
+            - \frac{8ϕ}{3π}
+      \end{align*}
+    ```
+
 ### [Pixel Covariance](@id bib-pixelcovariance)
 
 * M. Tegmark and A. de Oliveira-Costa. “How to measure CMB polarization power spectra

--- a/src/healpix.jl
+++ b/src/healpix.jl
@@ -14,7 +14,8 @@ export
     isnorth, issouth,
     isnorthcap, issouthcap, iscap,
     isnorthequbelt, issouthequbelt, isequbelt,
-    pix2ring, pix2ringidx, pix2z, pix2theta, pix2phi, pix2ang, pix2vec, ang2pix,
+    pix2ring, pix2ringidx, pix2z, pix2theta, pix2phi, pix2ang, pix2vec,
+    ang2pix, vec2pix,
     UNSEEN, ishealpixok, checkhealpix, InvalidNside, InvalidPixel
 
 using StaticArrays
@@ -415,13 +416,26 @@ end
     return unsafe_ang2pix(nside, θ, ϕ)
 end
 
+@fastmath function vec2pix(nside, r)
+    checkhealpix(nside)
+    length(r) == 3 || throw("r must be a 3-vector")
+    z = r[3]
+    ϕ = atan(r[2], r[1])
+    ϕ += ifelse(ϕ < zero(ϕ), oftype(ϕ, 2π), zero(ϕ))
+    return unsafe_zphi2pix(nside, z, ϕ)
+end
+
 """
     p = unsafe_ang2pix(nside, θ, ϕ)
 
 Like [`ang2pix`](@ref) but ...
 """
 @fastmath function unsafe_ang2pix(nside, θ, ϕ)
-    z = cos(θ)      # z-component
+    z = cos(θ)
+    return unsafe_zphi2pix(nside, z, ϕ)
+end
+
+@fastmath function unsafe_zphi2pix(nside, z, ϕ)
     z′ = abs(z)
     α = 2ϕ / π      # scaled distance around ring in [0,4)
                     # later advantage is that mod(ϕ, π/2) becomes modf(α)

--- a/src/healpix.jl
+++ b/src/healpix.jl
@@ -18,6 +18,7 @@ export
     ang2pix, vec2pix,
     UNSEEN, ishealpixok, checkhealpix, InvalidNside, InvalidPixel
 
+using Base: @propagate_inbounds
 using StaticArrays
 
 """
@@ -232,7 +233,7 @@ equatorial ring) for an `nside` HEALPix map.
 """
     i = pix2ring(nside, p)
 
-Computes the ring index `i` for the given pixel `p`. `nside` is the Nside resolution
+Computes the ring index `i` for the given pixel `p`, where `nside` is the Nside resolution
 factor.
 """
 @fastmath function pix2ring(nside::I, p::I) where I<:Integer
@@ -251,7 +252,7 @@ pix2ring(nside, p) = pix2ring(promote(nside, p)...)
 """
     j = pix2ringidx(nside, p)
 
-Computes the index `j` within the ring for the given pixel `p`. `nside` is the Nside
+Computes the index `j` within the ring for the given pixel `p`, where `nside` is the Nside
 resolution factor.
 """
 @fastmath function pix2ringidx(nside::I, p::I) where I<:Integer
@@ -273,8 +274,8 @@ pix2ringidx(nside, p) = pix2ringidx(promote(nside, p)...)
 """
     z = pix2z(nside, p)
 
-Computes the cosine of the colatitude `z` for the given pixel `p`. `nside` is the Nside
-resolution factor.
+Computes the cosine of the colatitude `z` for the given pixel `p`, where `nside` is the
+Nside resolution factor.
 """
 function pix2z(nside::I, p::I) where I<:Integer
     checkhealpix(nside, p)
@@ -305,7 +306,7 @@ end
 """
     θ = pix2theta(nside, p)
 
-Computes the colatitude `θ` for the given pixel `p`. `nside` is the Nside resolution
+Computes the colatitude `θ` for the given pixel `p`, where `nside` is the Nside resolution
 factor.
 """
 pix2theta(nside, p) = @fastmath acos(pix2z(promote(nside, p)...))
@@ -321,7 +322,7 @@ unsafe_pix2theta(nside, p) = acos(unsafe_pix2z(promote(nside, p)...))
 """
     ϕ = pix2phi(nside, p)
 
-Computes the azimuth `ϕ` for the given pixel `p`. `nside` is the Nside resolution
+Computes the azimuth `ϕ` for the given pixel `p`, where `nside` is the Nside resolution
 factor.
 """
 function pix2phi(nside::I, p::I) where I<:Integer
@@ -360,7 +361,8 @@ end
 """
     (θ,ϕ) = pix2ang(nside, p)
 
-Computes the colatitude and azimuth pair `(θ,ϕ)` for the given pixel `p`.
+Computes the colatitude and azimuth pair `(θ,ϕ)` for the given pixel `p`, where
+`nside` is the Nside resolution factor.
 """
 pix2ang(nside, p) = (pix2theta(nside, p), pix2phi(nside, p))
 
@@ -373,9 +375,10 @@ index validity.
 unsafe_pix2ang(nside, p) = (unsafe_pix2theta(nside, p), unsafe_pix2phi(nside, p))
 
 """
-    r::SVector{3} = pix2vec(nside, p)
+    r = pix2vec(nside, p)
 
-Computes the unit vector `r` pointing to the pixel center of the given pixel `p`.
+Computes the unit vector `r` pointing to the pixel center of the given pixel `p`, where
+`nside` is the Nside resolution factor.
 """
 function pix2vec(nside::I, p::I) where I<:Integer
     checkhealpix(nside, p)
@@ -407,34 +410,56 @@ end
 """
     p = ang2pix(nside, θ, ϕ)
 
-
+Computes the HEALPix pixel index `p` which contains the point ``(θ,ϕ)`` given by the
+colatitude `θ` and azimuth `ϕ`, where `nside` is the Nside resolution factor.
 """
 @fastmath function ang2pix(nside, θ, ϕ)
     checkhealpix(nside)
-    0 ≤ θ ≤ π || throw("θ must be in [0,π], but got $θ")
+    zero(θ) ≤ θ ≤ oftype(θ, π) || throw(DomainError("θ must be in [0,π], but got $θ"))
     ϕ = mod2pi(ϕ)
     return unsafe_ang2pix(nside, θ, ϕ)
 end
 
-@fastmath function vec2pix(nside, r)
+"""
+    p = vec2pix(nside, r)
+
+Computes the HEALPix pixel index `p` which contains the point at the end of the unit
+vector `r`, where `nside` is the Nside resolution factor.
+"""
+function vec2pix(nside, r)
     checkhealpix(nside)
-    length(r) == 3 || throw("r must be a 3-vector")
-    z = r[3]
-    ϕ = atan(r[2], r[1])
-    ϕ += ifelse(ϕ < zero(ϕ), oftype(ϕ, 2π), zero(ϕ))
-    return unsafe_zphi2pix(nside, z, ϕ)
+    length(r) == 3 || throw(DimensionMismatch("r must be a 3-vector"))
+    return @inbounds unsafe_vec2pix(nside, r)
 end
 
 """
     p = unsafe_ang2pix(nside, θ, ϕ)
 
-Like [`ang2pix`](@ref) but ...
+Like [`ang2pix`](@ref) but neither calls [`checkhealpix`](@ref) to check the validity of
+`nside` nor checks the domain of the spherical coordinates `θ` and `ϕ`.
 """
 @fastmath function unsafe_ang2pix(nside, θ, ϕ)
     z = cos(θ)
     return unsafe_zphi2pix(nside, z, ϕ)
 end
 
+"""
+    p = unsafe_vec2pix(nside, r)
+
+Like [`vec2pix`](@ref) but does not check the validity of the `nside` or length of `r`.
+"""
+@fastmath @propagate_inbounds function unsafe_vec2pix(nside, r)
+    z = r[3]
+    ϕ = atan(r[2], r[1])
+    ϕ += ifelse(ϕ < zero(ϕ), 2oftype(ϕ, π), zero(ϕ))
+    return unsafe_zphi2pix(nside, z, ϕ)
+end
+
+"""
+    p = unsafe_zphi2pix(nside, z, ϕ)
+
+Like [`unsafe_ang2pix`](@ref) but uses the value ``z = \\cos(θ)`` instead.
+"""
 @fastmath function unsafe_zphi2pix(nside, z, ϕ)
     z′ = abs(z)
     α = 2ϕ / π      # scaled distance around ring in [0,4)
@@ -477,4 +502,3 @@ end
 end
 
 end # module Healpix
-

--- a/test/healpix.jl
+++ b/test/healpix.jl
@@ -111,6 +111,7 @@ module Healpix
     @testset "Pixel identity" begin
         for pix in hpix4_pix
             @test pix == ang2pix(4, pix2ang(4, pix)...)
+            @test pix == vec2pix(4, pix2vec(4, pix))
         end
     end
 

--- a/test/healpix.jl
+++ b/test/healpix.jl
@@ -105,19 +105,23 @@ module Healpix
         end
         for ang2fn in (ang2pix,)
             @test_throws InvalidNside ang2fn(5, π/2, π/2)
+            @test_throws DomainError ang2fn(4, 2π, π/2) # θ > π when required π ∈ [0,π]
+        end
+        for vec2fn in (vec2pix,)
+            @test_throws InvalidNside vec2fn(5, Float64[0, 0, 1])
+            @test_throws DimensionMismatch vec2fn(4, Float64[0, 1])
+            @test_throws DimensionMismatch vec2fn(4, Float64[0, 0, 0, 1])
         end
     end
 
     @testset "Pixel identity" begin
-        for pix in hpix4_pix
-            @test pix == ang2pix(4, pix2ang(4, pix)...)
-            @test pix == vec2pix(4, pix2vec(4, pix))
-        end
+        @test all(pix == ang2pix(4, pix2ang(4, pix)...) for pix in hpix4_pix)
+        @test all(pix == vec2pix(4, pix2vec(4, pix)) for pix in hpix4_pix)
     end
 
     @testset "Wrap-around pixel ang2pix" begin
         # For pixel with centers at ϕ = 0, make sure the ϕ ≲ 0 (i.e. ϕ ≈ 2π - δϕ) are
-        # handled correctly.
+        # handled correctly. Only occurs within the equatorial belt.
         nside = 4
         _, ϕ₀ = pix2ang(nside, nside2npixcap(nside))
         ϕ₀ = -ϕ₀ / 2

--- a/test/healpix.jl
+++ b/test/healpix.jl
@@ -103,5 +103,28 @@ module Healpix
             @test_throws InvalidNside pix2fn(5,  0)
             @test_throws InvalidPixel pix2fn(4, -1)
         end
+        for ang2fn in (ang2pix,)
+            @test_throws InvalidNside ang2fn(5, π/2, π/2)
+        end
+    end
+
+    @testset "Pixel identity" begin
+        for pix in hpix4_pix
+            @test pix == ang2pix(4, pix2ang(4, pix)...)
+        end
+    end
+
+    @testset "Wrap-around pixel ang2pix" begin
+        # For pixel with centers at ϕ = 0, make sure the ϕ ≲ 0 (i.e. ϕ ≈ 2π - δϕ) are
+        # handled correctly.
+        nside = 4
+        _, ϕ₀ = pix2ang(nside, nside2npixcap(nside))
+        ϕ₀ = -ϕ₀ / 2
+        for ring in (nside+1):2:(2nside-1)
+            pix = nside2npixcap(nside) + 4nside*ring
+            θ,_ = pix2ang(nside, pix)
+            @test pix == ang2pix(nside, θ, ϕ₀)
+            @test pix == ang2pix(nside, θ, 2π + ϕ₀)
+        end
     end
 end


### PR DESCRIPTION
This adds the ability to turn coordinates (represented as either colatitude-azimuth pairs or as unit vectors) into the corresponding HEALPix pixel which contains the coordinate.