### PR TITLE
Tweak Travis CI settings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@
 language: julia
 os:
   - linux
-#  - osx
 julia:
   - 1.2
   - 1.3
@@ -12,19 +11,32 @@ branches:
     - master
     - /^v[0-9]+\.[0-9]+\.[0-9]+$/ # version tags for Documenter.jl
     - /^release-.*$/
-matrix:
+notifications:
+  email: false
+
+# Dependencies are pinned by a committed Manifest.toml and used for testing
+# on release version of Julia. On nightly, unpin all the dependencies (by
+# directly deleting Manifest.toml) and test with whatever the latest package
+# versions are.
+before_script:
+  - >
+    if [ x"$TRAVIS_JULIA_VERSION" == x"nightly" ]; then
+      echo "rm Manifest.toml";
+      rm Manifest.toml;
+    fi
+
+after_success:
+  - julia -e 'using Pkg; Pkg.add("Coverage"); using Coverage; Codecov.submit(process_folder())'
+
+jobs:
   allow_failures:
     - julia: nightly
   fast_finish: true
-notifications:
-  email: false
-after_success:
-  - julia -e 'using Pkg; Pkg.add("Coverage"); using Coverage; Codecov.submit(process_folder())'
-jobs:
   include:
     - stage: Documentation
       julia: 1.2
       os: linux
+      if: NOT type IN (pull_request)
       script: julia --project=docs -e '
           using Pkg;
           Pkg.develop(PackageSpec(path=pwd()));

--- a/Project.toml
+++ b/Project.toml
@@ -11,5 +11,5 @@ StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 
 [compat]
 Reexport = "≥0.2.0"
-StaticArrays = "≥0.11.0"
-julia = "1.2"
+StaticArrays = "≥0.11"
+julia = "≥1.2"


### PR DESCRIPTION
A test with two goals in mind:
1. Stop building the documentation on PR branches just to not deploy them. The doctests are run as part of the unit tests, so that should be good enough for now.
2. See if we can get nightly to use unpinned dependencies instead. We want to test with the oldest supported dependencies declared, so we pin those into a committed Manifest.toml, but we'd also like to test that newer packages work as well.