### PR TITLE
Add rudimentary/experimental routines for map synthesis

### DIFF
--- a/scripts/healpix_ylm.jl
+++ b/scripts/healpix_ylm.jl
@@ -1,0 +1,47 @@
+using Base.Threads
+using CMB
+using CMB.SphericalHarmonics: synthesize_ring
+using PyPlot, PyCall, Random
+
+const healpy = pyimport("healpy")
+
+nside = 512
+lmax = 1000 #3nside - 1
+
+Random.seed!(2)
+alms = zeros(ComplexF64, lmax, lmax)
+for l in 1:size(alms,1)
+    alms[l,1] = randn() ./ l
+    alms[l,2:end] .= complex.(randn.(), randn.()) ./ (l*sqrt(2))
+end
+llim = 100 #min(2nside, lmax)
+alms = alms[1:llim, 1:llim]
+
+function synthesize_healpix(nside, alms)
+    syn = zeros(nside2npix(nside))
+    @threads for rn in 1:2nside
+        # rn counts rings from the north pole; rs counts from the south pole
+        rs = 4nside - rn
+        if rn < nside # polar caps
+            npix = 4rn
+            pixfirstn = nside2npixcap(rn)
+            pixfirsts = nside2npix(nside) - pixfirstn - npix
+        else # equatorial belt
+            npix = 4nside
+            pixfirstn = nside2npixcap(nside) + 4nside * (rn - nside)
+            pixfirsts = pixfirstn + 4nside * (rs - rn)
+        end
+        θ, ϕ = pix2ang(nside, pixfirstn)
+
+        rings = synthesize_ring(alms, θ, ϕ, npix, Val(true))
+        syn[pixfirstn .+ (1:npix)] .= rings[1]
+        syn[pixfirsts .+ (1:npix)] .= rings[2]
+    end
+    return syn
+end
+syn = synthesize_healpix(nside, alms)
+
+# To match cartopy.Orthographic(30, 30), require arguments to be
+#     rot = (30-180, 30), flip = "geo", half_sky = true
+healpy.orthview(syn, rot = (30-180, 30), flip = "geo",
+                cmap = "RdBu_r", fig = 1)

--- a/src/CMB.jl
+++ b/src/CMB.jl
@@ -5,8 +5,8 @@ module CMB
     @reexport using .Sphere
 
     @reexport using Legendre
-    include("harmonics.jl")
-    @reexport using .Harmonics
+    include("sphericalharmonics.jl")
+    @reexport using .SphericalHarmonics
 
     include("healpix.jl")
     @reexport using .Healpix

--- a/src/harmonics.jl
+++ b/src/harmonics.jl
@@ -10,7 +10,7 @@ using LinearAlgebra: mul!
 function centered_range(start, stop, length)
     rng = range(start, stop, length=length+1)
     Δ = step(rng)
-    return range(start+Δ/2, stop-Δ/2, step=Δ)
+    return range(start+Δ/2, stop-Δ/2, length=length)
 end
 
 # Simple reference function which synthesizes field for an equidistant-cylindrical

--- a/src/harmonics.jl
+++ b/src/harmonics.jl
@@ -13,17 +13,55 @@ function centered_range(start, stop, length)
     return range(start+Δ/2, stop-Δ/2, length=length)
 end
 
+# Brute-force synthesis of the real-space points at (θ, ϕ) given a set of alms.
+# The idea is that there are no optimizations, so it is much easier to verify the
+# correctness of the function at the expense of a huge hit to performance. This will
+# primarily only be useful for testing development of the more specialized algorithms.
+function synthesize_reference(alms::AbstractMatrix{T}, θ, ϕ) where {T<:Complex}
+    R = real(T)
+    axes(θ) == axes(ϕ) || throw(DimensionMismatch("θ and ϕ must have same axes"))
+    lmax, mmax = size(alms) .- 1
+
+    Λ = Matrix{R}(undef, size(alms)...)
+    Φ = Vector{T}(undef, mmax + 1)
+    syn = Array{R}(undef, size(θ)...)
+
+    @inbounds for I in eachindex(syn)
+        # λ_ℓ^m(cos θ) factors
+        λlm!(Λ, lmax, mmax, cos(θ[I]))
+        # e^{imϕ} factors
+        #   Using complex(cospi(), sinpi()) rather than exp(complex()) gives slightly more
+        #   accurate results for test healpix rings
+        @. Φ = complex(cospi((0:mmax) * ϕ[I]/π), sinpi((0:mmax) * ϕ[I]/π))
+
+        acc = zero(R)
+        # Σ_{ℓ = 0}^{ℓmax}
+        for ℓ in 0:lmax
+            # Σ_{m = 0}^{mmax}
+            acc += real(alms[ℓ+1,1] * Λ[ℓ+1,1])
+            for m in 1:min(ℓ, mmax)
+                # Assuming alms were sourced from real field, alms are constrained such
+                # that
+                #    a_{ℓ(-m)} Y_ℓ^(-m) + a_{ℓ(+m)} Y_ℓ^(+m)
+                #    == 2 * Re[ a_{ℓ(+m)} Y_ℓ^(+m) ]
+                acc += 2 * real(alms[ℓ+1,m+1] * Λ[ℓ+1,m+1] * Φ[m+1])
+            end
+        end
+        syn[I] = acc
+    end
+    return syn
+end
+
 # Simple reference function which synthesizes field for an equidistant-cylindrical
 # project (ECP) grid on the entire sphere.
 function synthesize_ecp(alms::Matrix{T}, nx::Integer, ny::Integer) where {T<:Complex}
-    lmax, mmax = last.(axes(alms)) .- 1
+    lmax, mmax = size(alms) .- 1
     nxr = nx ÷ 2 + 1 # real-symmetric FFT's Nyquist length (index)
 
     # pixel grid definition for ECP
     θ = centered_range(0.0, 1.0π, ny)
     ϕ = centered_range(0.0, 2.0π, nx)
-    Δθ, Δϕ = step(θ), step(ϕ)
-    θ₀, ϕ₀ = first(θ), first(ϕ)
+    ϕ₀ = first(ϕ)
 
     ecp = Matrix{real(T)}(undef, nx, ny) # transposed to have x-dim have stride 1
     Λ = zeros(real(T), lmax+1, mmax+1)

--- a/src/sphericalharmonics.jl
+++ b/src/sphericalharmonics.jl
@@ -1,4 +1,4 @@
-module Harmonics
+module SphericalHarmonics
 
 # While under development, do not export these functions
 #export analyze, synthesize

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -28,6 +28,7 @@ end
 @testset ExtendedTestSet "CMB" begin
     @include "sphere.jl" "Spherical functions"
     @include "healpix.jl" "HEALPix functions"
+    @include "sphericalharmonics.jl" "Spherical Harmonics"
     @include "sparse.jl" "Sparse utilities"
     @include "doctests.jl" "Doctests"
 end

--- a/test/sphericalharmonics.jl
+++ b/test/sphericalharmonics.jl
@@ -1,6 +1,7 @@
 using Test
 using CMB.SphericalHarmonics
-using CMB.SphericalHarmonics: synthesize_reference, analyze_reference, centered_range
+using CMB.SphericalHarmonics: centered_range,
+    synthesize_reference, synthesize_ecp, synthesize_ring
 import ..NumTypes
 
 # Define the analytic expressions for the first few spherical harmonics; verify
@@ -12,39 +13,114 @@ Y20(θ, ϕ) =  sqrt(5 / 16oftype(θ, π)) * (3cos(θ)^2 - 1) * complex(true)
 Y21(θ, ϕ) = -sqrt(15 / 8oftype(θ, π)) * sin(θ) * cos(θ) * cis(ϕ)
 Y22(θ, ϕ) =  sqrt(15 / 32oftype(θ, π)) * sin(θ)^2 * cis(2ϕ)
 
-@testset "Analytic checks — synthesis (reference)" begin
-    n = 50
-    θ = repeat(centered_range(0.0, 1.0π, n), 1, 2n)
-    ϕ = repeat(centered_range(0.0, 2.0π, 2n)', n, 1)
+n = 50
+θ = repeat(centered_range(0.0, 1.0π, n), 1, 2n)
+ϕ = repeat(centered_range(0.0, 2.0π, 2n)', n, 1)
+θ′ = repeat(centered_range(0.0, 1.0π, n+1), 1, 2n+1)
+ϕ′ = repeat(centered_range(0.0, 2.0π, 2n+1)', n+1, 1)
 
-    # Generate complex fields from running real-only analysis on real and imaginary
-    # components separately.
-    function synth_ref_complex(ℓ, m, θ, ϕ, T::Type = Float64)
-        alms = zeros(Complex{T}, ℓ + 1, m + 1)
-        # Assign unit power to single delta (ℓ,m) mode.
-        #
-        # Real part
-        alms[ℓ+1,m+1] = 1
-        ref = complex(synthesize_reference(alms, θ, ϕ))
-        # Complex part -- Use (-im) not (+im) since the goal is to swap the internal
-        #                 (a + ib) to (b + ia), which requires multiplication by -im.
-        alms[ℓ+1,m+1] *= -im
-        ref += synthesize_reference(alms, θ, ϕ) .* im
-        # account for doubling due to assumption of real-only symmetry in synthesize_reference
-        ref ./= m == 0 ? 1 : 2
-        return ref
+# two sets of alms: one that is bandlimited below map Nyquist, and one that extends well
+# above the Nyquist
+lmax_lo = n ÷ 2 - 1
+lmax_hi = 2n
+alms_lo = zeros(ComplexF64, lmax_lo + 1, lmax_lo + 1)
+alms_hi = zeros(ComplexF64, lmax_hi + 1, lmax_hi + 1)
+for l in 1:lmax_hi
+    alms_hi[l+1,1] = randn()
+    alms_hi[l+1,2:l+1] .= randn.(ComplexF64)
+    if l ≤ lmax_lo
+        alms_lo[l+1,1:l+1] .= alms_hi[l+1,1:l+1]
     end
+end
 
-    @test Y00.(θ, ϕ) ≈ synth_ref_complex(0, 0, θ, ϕ)
-    @test Y10.(θ, ϕ) ≈ synth_ref_complex(1, 0, θ, ϕ)
-    @test Y11.(θ, ϕ) ≈ synth_ref_complex(1, 1, θ, ϕ)
-    @test Y20.(θ, ϕ) ≈ synth_ref_complex(2, 0, θ, ϕ)
-    @test Y21.(θ, ϕ) ≈ synth_ref_complex(2, 1, θ, ϕ)
-    @test Y22.(θ, ϕ) ≈ synth_ref_complex(2, 2, θ, ϕ)
+# Generate complex fields from running real-only analysis on real and imaginary
+# components separately.
+function synthesize_reference_complex(ℓ, m, θ, ϕ, T::Type = Float64)
+    alms = zeros(Complex{T}, ℓ + 1, m + 1)
+    # Assign unit power to single delta (ℓ,m) mode.
+    #
+    # Real part
+    alms[ℓ+1,m+1] = 1
+    ref = synthesize_reference(alms, θ, ϕ)
+    # Complex part -- Use (-im) not (+im) since the goal is to swap the internal
+    #                 (a + ib) to (b + ia), which requires multiplication by -im.
+    alms[ℓ+1,m+1] *= -im
+    ref += synthesize_reference(alms, θ, ϕ) .* im
+    # account for doubling due to assumption of real-only symmetry in synthesize_reference
+    ref ./= m == 0 ? 1 : 2
+    return ref
+end
+@testset "Analytic checks — synthesis (reference)" begin
+    # Validates the baseline reference implementation
+    @test Y00.(θ, ϕ) ≈ synthesize_reference_complex(0, 0, θ, ϕ)
+    @test Y10.(θ, ϕ) ≈ synthesize_reference_complex(1, 0, θ, ϕ)
+    @test Y11.(θ, ϕ) ≈ synthesize_reference_complex(1, 1, θ, ϕ)
+    @test Y20.(θ, ϕ) ≈ synthesize_reference_complex(2, 0, θ, ϕ)
+    @test Y21.(θ, ϕ) ≈ synthesize_reference_complex(2, 1, θ, ϕ)
+    @test Y22.(θ, ϕ) ≈ synthesize_reference_complex(2, 2, θ, ϕ)
 end
 
 @testset "Analytic checks — analysis (reference)" begin
 end
 
 @testset "Round trip synthesis/analysis (reference)" begin
+end
+
+function synthesize_ecp_complex(ℓ, m, nθ, nϕ, T::Type = Float64)
+    alms = zeros(Complex{T}, ℓ + 1, m + 1)
+    # Assign unit power to single delta (ℓ,m) mode.
+    #
+    # Real part
+    alms[ℓ+1,m+1] = 1
+    ref = synthesize_ecp(alms, nθ, nϕ)
+    # Complex part -- Use (-im) not (+im) since the goal is to swap the internal
+    #                 (a + ib) to (b + ia), which requires multiplication by -im.
+    alms[ℓ+1,m+1] *= -im
+    ref += synthesize_ecp(alms, nθ, nϕ) .* im
+    # account for doubling due to assumption of real-only symmetry in synthesize_reference
+    ref ./= m == 0 ? 1 : 2
+    return ref
+end
+@testset "Analytic checks — synthesis (Fast ECP)" begin
+    # Validates the optimizations:
+    #   * Iso-latitude sharing Legendre polynomials
+    #   * Ring-pair synthesis via polar symmetry
+    #   * FFT-based ϕ synthesis
+    @test Y00.(θ, ϕ) ≈ synthesize_ecp_complex(0, 0, n, 2n)
+    @test Y10.(θ, ϕ) ≈ synthesize_ecp_complex(1, 0, n, 2n)
+    @test Y11.(θ, ϕ) ≈ synthesize_ecp_complex(1, 1, n, 2n)
+    @test Y20.(θ, ϕ) ≈ synthesize_ecp_complex(2, 0, n, 2n)
+    @test Y21.(θ, ϕ) ≈ synthesize_ecp_complex(2, 1, n, 2n)
+    @test Y22.(θ, ϕ) ≈ synthesize_ecp_complex(2, 2, n, 2n)
+end
+
+@testset "Aliased ring synthesis" begin
+    # Checks that the fast FFT algorithm correctly includes the effects of aliasing
+    # high-m modes back down to low-m modes
+    ref = synthesize_reference(alms_hi, θ, ϕ)
+    ecp = synthesize_ecp(alms_hi, n, 2n)
+    @test ref ≈ ecp
+    # repeat again with one longer index to make sure even and odd cases both handled
+    # correctly.
+    ref = synthesize_reference(alms_hi, θ′, ϕ′)
+    ecp = synthesize_ecp(alms_hi, n+1, 2n+1)
+    @test ref ≈ ecp
+end
+
+@testset "Equality of ECP and per-ring synthesis" begin
+    # Test that the per-ring synthesis constructs equal answers as full ECP grid
+    ecp = synthesize_ecp(alms_hi, n, 2n)
+    ecp_r = fill(NaN, n, 2n)
+    ecp_p = fill(NaN, n, 2n)
+    for j in axes(θ, 1)
+        ecp_r[j,:] = synthesize_ring(alms_hi, θ[j,1], ϕ[j,1], 2n, Val(false))
+        if j ≤ (n + 1) ÷ 2
+            j′ = n - j + 1
+            ecp_pairs  = synthesize_ring(alms_hi, θ[j,1], ϕ[j,1], 2n, Val(true))
+            ecp_p[j, :] = ecp_pairs[1]
+            ecp_p[j′,:] = ecp_pairs[2]
+        end
+    end
+    @test ecp ≈ ecp_r
+    @test ecp ≈ ecp_p
 end

--- a/test/sphericalharmonics.jl
+++ b/test/sphericalharmonics.jl
@@ -1,0 +1,50 @@
+using Test
+using CMB.SphericalHarmonics
+using CMB.SphericalHarmonics: synthesize_reference, analyze_reference, centered_range
+import ..NumTypes
+
+# Define the analytic expressions for the first few spherical harmonics; verify
+# implementations against these.
+Y00(θ, ϕ) =  sqrt(1 / 4oftype(θ, π)) * complex(true)
+Y10(θ, ϕ) =  sqrt(3 / 4oftype(θ, π)) * cos(θ) * complex(true)
+Y11(θ, ϕ) = -sqrt(3 / 8oftype(θ, π)) * sin(θ) * cis(ϕ)
+Y20(θ, ϕ) =  sqrt(5 / 16oftype(θ, π)) * (3cos(θ)^2 - 1) * complex(true)
+Y21(θ, ϕ) = -sqrt(15 / 8oftype(θ, π)) * sin(θ) * cos(θ) * cis(ϕ)
+Y22(θ, ϕ) =  sqrt(15 / 32oftype(θ, π)) * sin(θ)^2 * cis(2ϕ)
+
+@testset "Analytic checks — synthesis (reference)" begin
+    n = 50
+    θ = repeat(centered_range(0.0, 1.0π, n), 1, 2n)
+    ϕ = repeat(centered_range(0.0, 2.0π, 2n)', n, 1)
+
+    # Generate complex fields from running real-only analysis on real and imaginary
+    # components separately.
+    function synth_ref_complex(ℓ, m, θ, ϕ, T::Type = Float64)
+        alms = zeros(Complex{T}, ℓ + 1, m + 1)
+        # Assign unit power to single delta (ℓ,m) mode.
+        #
+        # Real part
+        alms[ℓ+1,m+1] = 1
+        ref = complex(synthesize_reference(alms, θ, ϕ))
+        # Complex part -- Use (-im) not (+im) since the goal is to swap the internal
+        #                 (a + ib) to (b + ia), which requires multiplication by -im.
+        alms[ℓ+1,m+1] *= -im
+        ref += synthesize_reference(alms, θ, ϕ) .* im
+        # account for doubling due to assumption of real-only symmetry in synthesize_reference
+        ref ./= m == 0 ? 1 : 2
+        return ref
+    end
+
+    @test Y00.(θ, ϕ) ≈ synth_ref_complex(0, 0, θ, ϕ)
+    @test Y10.(θ, ϕ) ≈ synth_ref_complex(1, 0, θ, ϕ)
+    @test Y11.(θ, ϕ) ≈ synth_ref_complex(1, 1, θ, ϕ)
+    @test Y20.(θ, ϕ) ≈ synth_ref_complex(2, 0, θ, ϕ)
+    @test Y21.(θ, ϕ) ≈ synth_ref_complex(2, 1, θ, ϕ)
+    @test Y22.(θ, ϕ) ≈ synth_ref_complex(2, 2, θ, ϕ)
+end
+
+@testset "Analytic checks — analysis (reference)" begin
+end
+
+@testset "Round trip synthesis/analysis (reference)" begin
+end


### PR DESCRIPTION
This PR adds a few rudimentary functions which can synthesize maps from harmonic coefficients. Included are both a reference implementation which is a direct translation of the basic equations to loops — easy to understand, but also very slow.

Then there are two additional optimized routines which take advantage of invariants and symmetries that exist in iso-latitude pixelizations:
1. Pairs of rings reflected over the equator can be simultaneously synthesized from the same set of Legendre polynomials.
2. The summation over orders can be performed using an FFT rather than direct sums.
One version synthesizes basic ECP grids, which can be easily inspected as raw flat-maps or projected (with e.g. cartopy via PyPlot). The other version allows single isolatitude ring sythesis, which is sufficient to fill in a HEALPix map. (An example script is included to show how to do that.)

None of the routines have been particularly optimized/tuned beyond the two algorithmic items just mentioned above (so e.g. reusable buffers, in-place interfaces, etc). The goal was to just show that `Legendre.jl` is powerful enough to implement these. The reference implementation took literally a few minutes to write correctly. The FFT-based version took quite a bit longer, only because getting the aliasing behavior correct took some time to sort out.