### PR TITLE
Rewrite pixel covariance calculation

### DIFF
--- a/Manifest.toml
+++ b/Manifest.toml
@@ -15,6 +15,11 @@ git-tree-sha1 = "ecdec412a9abc8db54c0efc5548c64dfce072058"
 uuid = "b99e7846-7c00-51b0-8f62-c81ae34c0232"
 version = "0.5.10"
 
+[[BitFlags]]
+git-tree-sha1 = "176530c1403bccf653fe4fc173f059a841ed9b15"
+uuid = "d1d4a3ce-64b1-5f1a-9ba4-7e7e69966f35"
+version = "0.1.2"
+
 [[Conda]]
 deps = ["JSON", "VersionParsing"]
 git-tree-sha1 = "7a58bb32ce5d85f8bf7559aa7c2842f9aecf52fc"

--- a/Project.toml
+++ b/Project.toml
@@ -4,6 +4,7 @@ author = ["Justin Willmert <justin@willmert.me>"]
 version = "0.2.2"
 
 [deps]
+BitFlags = "d1d4a3ce-64b1-5f1a-9ba4-7e7e69966f35"
 FFTW = "7a1cc6ca-52ef-59f5-83cd-3a7055c09341"
 Legendre = "7642852e-7f09-11e9-134e-0940411082b6"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/src/pixelcovariance.jl
+++ b/src/pixelcovariance.jl
@@ -310,7 +310,7 @@ function pixelcovariance(nside, pixels, pixind)
     return cache
 end
 
-function pixelcovariance!(cache::PixelCovarianceCache, C::AbstractMatrix, Cl::AbstractMatrix)
+function pixelcovariance!(cache::PixelCovarianceCache, cov::AbstractMatrix, Cl::AbstractMatrix)
     T = eltype(cache.F)
     fourpi = 4 * convert(T, π)
     # N.B. In general, the spectrum causes Cl*F to decrease rapidly as ℓ → ∞; reverse
@@ -331,7 +331,7 @@ function pixelcovariance!(cache::PixelCovarianceCache, C::AbstractMatrix, Cl::Ab
                 tt = muladd(ClTT, cache.F[ll,1], tt) # tt + ClTT*cache.F[ll,1]
             end
             tt /= fourpi
-            C[i,1] = tt # TT
+            cov[i,1] = tt # TT
         end
 
         # TQ and TU
@@ -346,10 +346,10 @@ function pixelcovariance!(cache::PixelCovarianceCache, C::AbstractMatrix, Cl::Ab
             end
             tq /= fourpi
             tu /= fourpi
-            C[i,2] =  tq*cache.cij[i] + tu*cache.sij[i] # QT
-            C[i,3] = -tq*cache.sij[i] + tu*cache.cij[i] # QU
-            C[i,4] =  tq*cache.cji[i] + tu*cache.sji[i] # TQ
-            C[i,7] = -tq*cache.sji[i] + tu*cache.cji[i] # TU
+            cov[i,2] =  tq*cache.cij[i] + tu*cache.sij[i] # QT
+            cov[i,3] = -tq*cache.sij[i] + tu*cache.cij[i] # QU
+            cov[i,4] =  tq*cache.cji[i] + tu*cache.sji[i] # TQ
+            cov[i,7] = -tq*cache.sji[i] + tu*cache.cji[i] # TU
         end
 
         # QQ, QU, and UU
@@ -375,14 +375,14 @@ function pixelcovariance!(cache::PixelCovarianceCache, C::AbstractMatrix, Cl::Ab
             cji = cache.cji[i]
             sij = cache.sij[i]
             sji = cache.sji[i]
-            C[i,5] =  qq*cij*cji + qu*(cij*sji+sij*cji) + uu*sij*sji # QQ
-            C[i,6] = -qq*sij*cji + qu*(cij*cji-sij*sji) + uu*cij*sji # UQ
-            C[i,8] = -qq*cij*sji + qu*(cij*cji-sij*sji) + uu*sij*cji # QU
-            C[i,9] =  qq*sij*sji - qu*(cij*sji+sij*cji) + uu*cij*cji # UU
+            cov[i,5] =  qq*cij*cji + qu*(cij*sji+sij*cji) + uu*sij*sji # QQ
+            cov[i,6] = -qq*sij*cji + qu*(cij*cji-sij*sji) + uu*cij*sji # UQ
+            cov[i,8] = -qq*cij*sji + qu*(cij*cji-sij*sji) + uu*sij*cji # QU
+            cov[i,9] =  qq*sij*sji - qu*(cij*sji+sij*cji) + uu*cij*cji # UU
         end
     end
 
-    return cache
+    return cov
 end
 
 end # module PixelCovariance

--- a/src/pixelcovariance.jl
+++ b/src/pixelcovariance.jl
@@ -95,7 +95,7 @@ function unsafe_Fweights!(workornorm::Union{AbstractLegendreNorm,FweightsWork}, 
         F′ = F
     end
     if workornorm isa AbstractLegendreNorm
-        work = FweightsWork(LegendreUnitNorm(), F′, x′)
+        work = FweightsWork(workornorm, F′, x′)
         @inbounds _Fweights_impl!(work, F′, lmax, x′)
     else
         @inbounds _Fweights_impl!(workornorm, F′, lmax, x′)

--- a/src/pixelcovariance.jl
+++ b/src/pixelcovariance.jl
@@ -328,7 +328,8 @@ function pixelcovariance!(cache::PixelCovarianceCache, cov::AbstractMatrix, Cl::
             tt = zero(T)
             @simd for ll in R
                 ClTT = Cl[ll,1]
-                tt = muladd(ClTT, cache.F[ll,1], tt) # tt + ClTT*cache.F[ll,1]
+                F00 = cache.F[ll, 1]
+                tt = muladd(ClTT, F00, tt) # tt + ClTT*F00
             end
             tt /= fourpi
             cov[i,1] = tt # TT
@@ -341,8 +342,9 @@ function pixelcovariance!(cache::PixelCovarianceCache, cov::AbstractMatrix, Cl::
             @simd for ll in R
                 ClTE = Cl[ll,4]
                 ClTB = Cl[ll,5]
-                tq = muladd(-ClTE, cache.F[ll,2], tq) # tq - ClTE*cache.F[ll,2]
-                tu = muladd(-ClTB, cache.F[ll,2], tu) # tu - ClTB*cache.F[ll,2]
+                F10 = F[ll,2]
+                tq = muladd(-ClTE, F10, tq) # tq - ClTE*F10
+                tu = muladd(-ClTB, F10, tu) # tu - ClTB*F10
             end
             tq /= fourpi
             tu /= fourpi

--- a/src/pixelcovariance.jl
+++ b/src/pixelcovariance.jl
@@ -356,8 +356,13 @@ end
 
 function pixelcovariance!(cache::PixelCovarianceCache, C::AbstractMatrix)
     T = eltype(cache.F)
-    R = reverse(axes(cache.F, 1))
     fourpi = 4 * convert(T, π)
+    # N.B. In general, the spectrum causes Cl*F to decrease rapidly as ℓ → ∞; reverse
+    #      the order of summation to accumulate from smallest to largest magnitude values.
+    # TODO: Look into using and compare this assumption against Julia's built-in sum() which
+    #       uses a divide-and-conquered summation to increase numerical precision in general
+    #       cases.
+    R = reverse(axes(cache.F, 1))
 
     @inbounds for (i,z) in enumerate(cache.z)
         Fweights!(LegendreUnitNorm(), cache.F, cache.lmax, z)

--- a/test/Makefile
+++ b/test/Makefile
@@ -1,8 +1,12 @@
 JULIA ?= $(shell which julia)
 usecolor = $(shell test -t 0 && echo "--color=yes" || echo "--color=no")
+mkfile_path := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
 
-.DUMMY: test
+.PHONY: test
 
 test:
-	$(JULIA) $(usecolor) --check-bounds=yes \
-		-e 'Pkg.build("CMB"); Pkg.test("CMB");'
+	cd $(realpath $(mkfile_path)..) && \
+	$(JULIA) $(usecolor) --startup-file=no --project=test/ \
+		-e 'using Pkg; Pkg.develop(PackageSpec(path=pwd())); Pkg.instantiate()' && \
+	$(JULIA) $(usecolor) --check-bounds=yes --startup-file=no --project=test/ \
+		test/runtests.jl ${DOCARGS}

--- a/test/pixelcovariance.jl
+++ b/test/pixelcovariance.jl
@@ -40,15 +40,15 @@ using LinearAlgebra, Random
         using Base: OneTo
 
         nel = prod(length.(axs))
-        X1 = reshape(collect(range(-1, 1, length=nel)), length.(axs)...)
-        Xo = reshape(copy(X1), axs...)
-        F1 = zeros(length.(axs)..., lmax+1, 4)
+        Xr = reshape(collect(range(-1, 1, length=nel)), length.(axs)...)
+        Xo = reshape(copy(Xr), axs...)
+        Fr = zeros(length.(axs)..., lmax+1, 4)
         Fo = zeros(axs..., lmax+1, 4)
 
-        F!(F1, lmax, X1)
+        F!(Fr, lmax, Xr)
         F!(Fo, lmax, Xo)
-        @test F1 == parent(Fo) # Equality of values
-        @test_throws DimensionMismatch F!(F1, lmax, Xo) # Mismatched axes
+        @test Fr == parent(Fo) # Equality of values
+        @test_throws DimensionMismatch F!(Fr, lmax, Xo) # Mismatched axes
     end
 
     @testset "Even/Odd symmetry" begin

--- a/test/pixelcovariance.jl
+++ b/test/pixelcovariance.jl
@@ -94,16 +94,9 @@ const nbufs_FweightsWork = 2 + nbufs_LegendreWork # y, xy; x aliased to Legendre
         nbN = sizeof(workN.x) * nbufs_FweightsWork
         @test nb1 <= @allocated unsafe_Fweights!(norm, F1, lmax, x)
         @test nbN <= @allocated unsafe_Fweights!(norm, FN, lmax, z)
-        # Allocation tracking and/or compiler ellision is less successful on versions older
-        # than v1.5. Just make sure we're not allocating all the temporary buffers, but
-        # allow for small allocations (like maybe a `view()` container).
-        @static if VERSION < v"1.5-beta1"
-            @test nb1 > @allocated unsafe_Fweights!(work1, F1, lmax, x)
-            @test nbN > @allocated unsafe_Fweights!(workN, FN, lmax, z)
-        else
-            @test 0 == @allocated unsafe_Fweights!(work1, F1, lmax, x)
-            @test 0 == @allocated unsafe_Fweights!(workN, FN, lmax, z)
-        end
+        # Pre-allocated version doesn't allocate
+        @test 0 == @allocated unsafe_Fweights!(work1, F1, lmax, x)
+        @test 0 == @allocated unsafe_Fweights!(workN, FN, lmax, z)
     end
 end
 
@@ -129,14 +122,8 @@ end
         nb += sizeof(eltype(first(pix))) * 4 * (lmax + 1)
         @test nb <= @allocated unsafe_pixelcovariance!(norm, cov, pix, pixind, Cl, fields)
 
-        # Allocation tracking and/or compiler ellision is less successful on versions older
-        # than v1.5. The stated allocations seem to be much larger than the expected
-        # buffers (and output from `julia --track-allocation=user` shows clearly nonsensical
-        # allocations) so simply mark the test as broken on older versions.
-        @static if VERSION < v"1.5.0-beta1"
-            @test_broken nb > @allocated unsafe_pixelcovariance!(work, cov, pix, pixind, Cl, fields)
-        else
-            @test 0 == @allocated unsafe_pixelcovariance!(work, cov, pix, pixind, Cl, fields)
-        end
+        # Currently broken, even on v1.5 --- haven't figured out where the allocations are
+        # happening
+        @test_broken nb > @allocated unsafe_pixelcovariance!(work, cov, pix, pixind, Cl, fields)
     end
 end

--- a/test/sphere.jl
+++ b/test/sphere.jl
@@ -177,6 +177,7 @@ end
     # Reckoning from the poles when called with colatitude-azimuth pairs takes advantage
     # of the given azimuth to move along the given meridian rather that of only the
     # prime meridian's great circle.
+    Random.seed!(1234)
     α = rand(T)
     @test all(reckon(zero(T), ϕ, rand(T), α)[2] ≈ mod2pi(T(π)-α + ϕ) for ϕ in rand(T, 50))
     @test all(reckon(T(π),    ϕ, rand(T), α)[2] ≈ α + ϕ              for ϕ in rand(T, 50))


### PR DESCRIPTION
This PR starts the rewrite of `pixelcovariance!` with the lessons learned from the implementation of `Legendre.legendre!` in mind. In particular, the new experimental interface where the set of pre-allocated working space buffer can be provided to an `unsafe_pixelcovariance!` function should allow making properly threaded or parallelized high-level abstractions easier.
The contents of this PR are very much feature incomplete, but it should be a good start.
A major TODO is to add mathematical tests of the output of the pixel-pixel covariance calculation since this is so far completely unvalidated (it's just simply known to not crash...).