### PR TITLE
Tests and validation of pixel-pixel covariance calculation

### DIFF
--- a/src/pixelcovariance.jl
+++ b/src/pixelcovariance.jl
@@ -32,7 +32,8 @@ function FweightsWork(norm::AbstractLegendreNorm, F, z)
 end
 
 @inline function coeff_η(::Type{T}, l::Integer) where T
-    return T(2l + 1)
+    lT = convert(T, l)
+    return T(2lT + one(T))
 end
 @inline function coeff_χ(::Type{T}, l::Integer) where T
     lT = convert(T, l)
@@ -42,7 +43,7 @@ end
 end
 @inline function coeff_γ(::Type{T}, l::Integer) where T
     lT = convert(T, l)
-    fac1 = 2 * T(lT + one(T))
+    fac1 = 2 * T(2lT + one(T))
     fac2 = @evalpoly(lT, 0, -2, -1, 2, 1)
     return fac1 / fac2
 end

--- a/src/pixelcovariance.jl
+++ b/src/pixelcovariance.jl
@@ -217,9 +217,22 @@ subblocks, named as the Cartesian product of elements T, Q, and U:
     QT  QQ  QU
     UT  UQ  UU
 """
-@bitflag CovarianceFields TT TQ TU QT QQ QU UT UQ UU NO_FIELD=0
+@bitflag CovarianceFields TT QT UT TQ QQ UQ TU QU UU NO_FIELD=0
 const TPol = TQ | TU | UT | QT
 const Pol  = QQ | UU | QU | UQ
+
+function minrow(fields::CovarianceFields)
+    F = Integer(fields)
+    f = (F | (F >> 0x3) | (F >> 0x6)) & 0x07
+    return trailing_zeros(f) + 0x1
+end
+
+function mincol(fields::CovarianceFields)
+    F = Integer(fields)
+    f = (F | (F >> 0x1) | (F >> 0x2)) & 0b001001001 #= 0x49 =#
+    f = (f | (f >> 0x2) | (f >> 0x4)) & 0b111 #= 0x07 =#
+    return trailing_zeros(f) + 0x1
+end
 
 function pixelcovariance(pix::AbstractVector, Cl::AbstractMatrix, fields::CovarianceFields)
     T = eltype(first(pix))

--- a/src/pixelcovariance.jl
+++ b/src/pixelcovariance.jl
@@ -342,7 +342,7 @@ end
             tq /= fourpi
             tu /= fourpi
             cov[ii,2] =  tq*cij + tu*sij # QT
-            cov[ii,3] = -tq*sij + tu*cij # QU
+            cov[ii,3] = -tq*sij + tu*cij # UT
             cov[ii,4] =  tq*cji + tu*sji # TQ
             cov[ii,7] = -tq*sji + tu*cji # TU
         end

--- a/src/pixelcovariance.jl
+++ b/src/pixelcovariance.jl
@@ -238,10 +238,11 @@ function pixelcovariance!(cov::AbstractMatrix, pix::AbstractVector, pixind,
                           Cl::AbstractMatrix, fields::CovarianceFields)
     axes(cov, 1) == axes(pix, 1) ||
         throw(DimensionMismatch("Axes of covariance matrix and pixel vector do not match"))
-    axes(cov, 2) == 9
+    size(cov, 2) == 9 ||
+        throw(DimensionMismatch("Output array expected to have 9 columns"))
+    size(Cl, 2) == 6 || throw(DimensionMismatch("Expected 6 Cl spectra"))
     Base.checkbounds(pix, pixind)
     Base.require_one_based_indexing(Cl)
-    size(Cl, 2) == 6 || throw(DimensionMismatch("Expected 6 Cl spectra"))
 
     return unsafe_pixelcovariance!(LegendreUnitNorm(), cov, pix, pixind, Cl, fields)
 end

--- a/test/pixelcovariance.jl
+++ b/test/pixelcovariance.jl
@@ -80,6 +80,19 @@ const nbufs_FweightsWork = 2 + nbufs_LegendreWork # y, xy; x aliased to Legendre
         end
     end
 
+    @testset "Limits at x = ±1" begin
+        x₁ = [-1.0, -1.0 + 2sqrt(eps(1.0))]
+        x₂ = [ 1.0,  1.0 - 2sqrt(eps(1.0))]
+        Fx = zeros(2, lmax+1, 4)
+
+        # Only a rough check of 1 part in 10000 agreement is sufficient to verify that
+        # a factor-of-2 bug no longer exists.
+        F!(Fx, lmax, x₁)
+        @test mapreduce(<(1e-4) ∘ abs, &, diff(Fx[:,2:4,:], dims=1))
+        F!(Fx, lmax, x₂)
+        @test mapreduce(<(1e-4) ∘ abs, &, diff(Fx[:,2:4,:], dims=1))
+    end
+
     @testset "Preallocated work space" begin
         using CMB.PixelCovariance: unsafe_Fweights!
         x = z[2]


### PR DESCRIPTION
This PR is a follow-up to #30 — that PR reworked the implementation of the pixel-pixel covariance calculation, while this one is aimed at filling in the tests and validation of the implementation.