### PR TITLE
Improve/Expand implementation of pixel-pixel covariance calculations

### DIFF
--- a/docs/src/lib/public.md
+++ b/docs/src/lib/public.md
@@ -22,3 +22,14 @@ Private = false
 Modules = [CMB.PixelCovariance]
 Private = false
 ```
+
+The following enums/bit flags are not exported globally, but all of the named values can
+be imported into a scope by `using` the parent module (e.g. to access all of the
+covariance field constants, use `using CMB.PixelCovariance.CovarianceFields`.
+
+```@docs
+CMB.PixelCovariance.PolarizationConventions.Convention
+CMB.PixelCovariance.CovarianceFields.Field
+CMB.PixelCovariance.CovarianceFields.TPol
+CMB.PixelCovariance.CovarianceFields.Pol
+```

--- a/docs/src/man/pixelcov.md
+++ b/docs/src/man/pixelcov.md
@@ -11,7 +11,7 @@ Pages = ["pixelcov.md"]
 Depth = 2
 ```
 
-## [Definition and Properties](@id pixelcov_defn)
+## [Definition](@id pixelcov_defn)
 
 The following definitions are a lightly-modified reproduction of Appendix A
 of [Tegmark & Oliveira-Costa (2001)](@ref bib-pixelcovariance).
@@ -70,20 +70,21 @@ In this simplified case, the 6 unique covariances are
 ```
 for ``z_{ij} = \cos(\sigma_{ij})`` and some fiducial spectrum ``C_\ell``.
 The polarization weighting functions are simple functions of the ``P_\ell`` and
-``P_\ell^2`` associated Legendre polynomials,
+``P_\ell^2``
+[associated Legendre polynomials](https://jmert.github.io/Legendre.jl/stable/),
 ```math
 \begin{align}
-    \covF{00} &= (2\ell + 1) P_\ell(z_{ij})
+    \covF{00} &\equiv (2\ell + 1) P_\ell(z_{ij})
         \label{eqn:theorycov:F00}
     \\
-    \covF{10} &= \chi_\ell
+    \covF{10} &\equiv \chi_\ell
         \left[
         \frac{z_{ij}}{1-z_{ij}^2} P_{\ell-1}(z_{ij}) - \left(
         \frac{1}{1-z_{ij}^2} + \frac{\ell-1}{2} \right)P_\ell(z_{ij})
         \right]
         \label{eqn:theorycov:F10}
     \\
-    \covF{12} &= \gamma_\ell
+    \covF{12} &\equiv \gamma_\ell
         \left[
         \frac{\ell+2}{1-z_{ij}^2} z_{ij} P^2_{\ell-1}(z_{ij}) - \left(
         \frac{\ell-4}{1-z_{ij}^2} + \frac{\ell(\ell-1)}{2} \right)
@@ -91,7 +92,7 @@ The polarization weighting functions are simple functions of the ``P_\ell`` and
         \right]
         \label{eqn:theorycov:F12}
     \\
-    \covF{22} &= 2\gamma_\ell
+    \covF{22} &\equiv 2\gamma_\ell
         \left[
         \frac{\ell+2}{1-z_{ij}^2} P^2_{\ell-1}(z_{ij}) -
         \frac{\ell-1}{1-z_{ij}^2} z_{ij} P^2_\ell(z_{ij})
@@ -148,6 +149,129 @@ Also note that these rotations move the covariances into the IAU
 polarization convention — to move into the `HEALPix` polarization convention,
 the rotations both need to be reversed, i.e. ``\mat R \leftrightarrow \mat
 R^\top``.
+
+The pixel-pixel covariance matrix ``\mat C`` for some set of pixels is constructed by
+calculating the terms in ``{\mat C}_{ij}`` for each pair of pixels and filling in the 9
+values as the ``(i,j)``-th entries of the covariance blocks in ``\mat C``.
+By blocks, we refer to the fact that ``\mat C`` can be block-decomposed as
+```math
+\begin{align}
+    \mat C &= \begin{bmatrix}
+        \mat C^{TT} & \mat C^{TQ} & \mat C^{TU} \\
+        \mat C^{QT} & \mat C^{QQ} & \mat C^{QU} \\
+        \mat C^{UT} & \mat C^{UQ} & \mat C^{UU}
+    \end{bmatrix}
+\end{align}
+```
+For example, if one holds $j$ constant and varies $i \in P$ across all pixels,
+then one would form 3 columns of $\mat C$, one in each of the block-columns.
+
+It is also convenient to define the polarization-only block decompositions of the total
+covariance matrix as
+```math
+\begin{align}
+    \mat C^{\mathrm{Pol}} &\equiv \begin{bmatrix}
+        \mat C^{QQ} & \mat C^{QU} \\
+        \mat C^{UQ} & \mat C^{UU} \end{bmatrix}
+\end{align}
+```
+
+## Properties and Symmetries
+
+- The entire covariance matrix ``\mat C`` is symmetric.
+  Therefore the on-diagonal sub-blocks ``\mat C^{TT}``, ``\mat C^{QQ}``, and
+  ``\mat C^{UU}`` are individually symmetric as well, and the off-diagonal blocks must
+  be related to one another as
+  ```math
+  \begin{align*}
+      \mat C^{TQ} &= \left(\mat C^{QT}\right)^\top &
+      \mat C^{TU} &= \left(\mat C^{UT}\right)^\top &
+      \mat C^{QU} &= \left(\mat C^{UQ}\right)^\top
+  \end{align*}
+  ```
+  This directly implies the polarization-only matrix ``\mat C^{\mathrm{Pol}}`` is
+  symmetric as well.
+- The covariance matrices ``\mat C``, ``\mat C^{TT}``, and ``\mat C^{\mathrm{Pol}}`` are at
+  least positive-semidefinite for appropriate non-zero fiducial input spectra.
+  Positive-definiteness only occurs when there are at least as many non-zero harmonic modes
+  (``C_\ell^{XY} \neq 0`` over all spectra ``XY``) as there are diagonal elements in the
+  matrix (the number of pixels in the map(s) that the covariance describes).
+- The covariance matrices are linear in the fiducial spectra.
+  For example, an ``EE``-only covariance matrix ``[\mat C]^{EE}`` (wherein all ``C_\ell =
+  0`` except for ``C_\ell^{EE}`` which is non-zero somewhere) and an ``EB``-only covariance
+  matrix ``[\mat C]^{EB}`` can be summed to define
+  ```math
+  \begin{align*}
+      [\mat C]^{EEEB} = [\mat C]^{EE} + [\mat C]^{EB}
+  \end{align*}
+  ```
+  which is equivalent to the covariance matrix which would have been produced if the
+  fiducial spectrum had included the both of the ``C_\ell^{EE}`` and ``C_\ell^{EB}``
+  spectra from the start.
+- Since the IAU and HEALPix polarization conventions differ by the direction of rotation
+  in ``\mat R(\alpha)`` which corresponds to a change in the sign of the ``\sin`` terms
+  (``\sij`` and ``\sji``), the cosmologically-interesting case where ``C_\ell^{EB} = 0``
+  and ``C_\ell^{TB} = 0`` also simplifies such that the following are also true:
+  ```math
+  \begin{align*}
+      {\mat C}_{ij,\mathrm{Healpix}}^{TU} &= -{\mat C}_{ij,\mathrm{IAU}}^{TU} &
+      {\mat C}_{ij,\mathrm{Healpix}}^{UT} &= -{\mat C}_{ij,\mathrm{IAU}}^{UT} \\
+      {\mat C}_{ij,\mathrm{Healpix}}^{QU} &= -{\mat C}_{ij,\mathrm{IAU}}^{QU} &
+      {\mat C}_{ij,\mathrm{Healpix}}^{UQ} &= -{\mat C}_{ij,\mathrm{IAU}}^{UQ}
+  \end{align*}
+  ```
+  and the remaining block components are unchanged.
+
+## Mathematical Details
+
+It is often useful to have the fully-expanded expressions for each of the pixel-pixel
+covariance terms after applying the local-to-global coordinate system rotations.
+If we define short-cut notation for each of the terms in the rotation matrices
+as
+```math
+\begin{align*}
+    \mat R(\alpha_{ij}) &\equiv \begin{bmatrix}
+        1 & 0 & 0 \\
+        0 & \cij & -\sij \\
+        0 & \sij &  \cij
+    \end{bmatrix}
+    &
+    \mat R(\alpha_{ji})^\top &\equiv \begin{bmatrix}
+        1 & 0 & 0 \\
+        0 &  \cji & \sji \\
+        0 & -\sji & \cji
+    \end{bmatrix}
+\end{align*}
+```
+then expanding Eqn. ``\ref{eqn:theorycov:rotate}`` explicitly (and grouping the terms
+by block-columns):
+```math
+\begin{align*}
+    \begin{bmatrix}
+            {\mat C}_{ij}^{TT} \\ {\mat C}_{ij}^{QT} \\ {\mat C}_{ij}^{UT}
+        \end{bmatrix} &= \begin{bmatrix}
+            \covTT \\
+            \covTQ\cij - \covTU\sij \\
+            \covTQ\sij + \covTU\cij
+        \end{bmatrix}
+    \\
+    \begin{bmatrix}
+            {\mat C}_{ij}^{TQ} \\ {\mat C}_{ij}^{QQ} \\ {\mat C}_{ij}^{UQ}
+        \end{bmatrix} &= \begin{bmatrix}
+            \covTQ\cji - \covTU\sji \\
+            \covQQ\cij\cji - \covQU(\cij\sji + \sij\cji) + \covUU\sij\sji \\
+            \covQQ\sij\cji + \covQU(\cij\cji - \sij\sji) - \covUU\cij\sji
+        \end{bmatrix}
+    \\
+    \begin{bmatrix}
+            {\mat C}_{ij}^{TU} \\ {\mat C}_{ij}^{QU} \\ {\mat C}_{ij}^{UU}
+        \end{bmatrix} &= \begin{bmatrix}
+            \covTQ\sji + \covTU\cji \\
+            \covQQ\cij\sji + \covQU(\cij\cji - \sij\sji) - \covUU\sij\cji \\
+            \covQQ\sij\sji + \covQU(\cij\sji + \sij\cji) + \covUU\cij\cji
+        \end{bmatrix}
+\end{align*}
+```
 
 ---
 


### PR DESCRIPTION
1. Clean up namespacing a bit — namely, put bit flags and enums within internal modules so that the names can be easily imported into any scope with a `using` directive and without being automatically exported and polluting the namespace.
2. Add the ability to change the polarization convention used in the covariance calculations.