### PR TITLE
Support calculating multiple covariance columns in a single call

### DIFF
--- a/src/pixelcovariance.jl
+++ b/src/pixelcovariance.jl
@@ -293,10 +293,11 @@ end
 function pixelcovariance!(cov::AbstractMatrix, pix::AbstractVector, pixind,
                           Cl::AbstractMatrix, fields::Field,
                           polconv::Convention = IAUConv)
+    N = ndims(cov)
     axes(cov, 1) == axes(pix, 1) ||
         throw(DimensionMismatch("Axes of covariance matrix and pixel vector do not match"))
-    size(cov, 2) == 9 ||
-        throw(DimensionMismatch("Output array expected to have 9 columns"))
+    axes(cov, N) == OneTo(9) ||
+        throw(DimensionMismatch("Covariance output expected to have trailing dimension of length 9"))
     size(Cl, 2) == 6 || throw(DimensionMismatch("Expected 6 Cl spectra"))
     Base.checkbounds(pix, pixind)
     Base.require_one_based_indexing(Cl)

--- a/test/pixelcovariance.jl
+++ b/test/pixelcovariance.jl
@@ -167,11 +167,24 @@ end
     end
 
     @testset "Domain Checking" begin
+        # Bad pixind shape
+        @test_throws DimensionMismatch pixelcovariance!(cov, pix, ones(2, 2), Cl, fields)
+
         # Incorrectly-sized output arrays
         @test_throws DimensionMismatch pixelcovariance!(zeros(   0, 9), pix, 1, Cl, fields)
         @test_throws DimensionMismatch pixelcovariance!(zeros(npix, 8), pix, 1, Cl, fields)
+        @test_throws DimensionMismatch pixelcovariance!(zeros(   0, 9), pix, 1:npix, Cl, fields)
+        @test_throws DimensionMismatch pixelcovariance!(zeros(npix, 9), pix, 1:npix, Cl, fields)
+
+        @test_throws DimensionMismatch pixelcovariance!(zeros(npix, npix,   9), pix, 1, Cl, fields)
+        @test_throws DimensionMismatch pixelcovariance!(zeros(npix, npix-1, 9), pix, 1:npix, Cl, fields)
+        @test_throws DimensionMismatch pixelcovariance!(zeros(npix, npix,   8), pix, 1:npix, Cl, fields)
+
+        @test_throws DimensionMismatch pixelcovariance!(zeros(npix, npix, 9, 1), pix, 1:npix, Cl, fields)
+
         # Incorrectly-sized spectra arrays
         @test_throws DimensionMismatch pixelcovariance!(cov, pix, 1, zeros(lmax, 5), fields)
+
         # Pixel indexing is inbounds
         @test_throws BoundsError pixelcovariance!(cov, pix, -1, Cl, fields)
         @test_throws BoundsError pixelcovariance!(cov, pix, npix+1, Cl, fields)

--- a/test/pixelcovariance.jl
+++ b/test/pixelcovariance.jl
@@ -149,7 +149,7 @@ end
         end
         return maxerror, maxvalue
     end
-    function isnearlysymmetric(A; ulps = 0.01)
+    function isnearlysymmetric(A; ulps = 0.1)
         maxerr, maxval = asymmetry(A)
         return maxerr / eps(maxval) ≤ ulps
     end


### PR DESCRIPTION
This change implements the support for calculating the covariance matrix over multiple pixel indices, thereby allowing the calculation of the pixel-pixel covariance over multiple columns of the full matrix with a single call.

At the same time, tests for non-1-based indexing have been added since the core code has been designed to work with offset axes but had thus far not actually been exercised.

I'm still not 100% sure the layout of `cov` is what we want, but that can be addressed in a follow-up PR. (To be precise, I wonder if it would make sense to interleave the field dimensions with the pixel dimensions — that is, a multi-column covariance output array would be npix × 3 × npixind × 3 in size. Then if npixind == npix, the full covariance matrix is simply a `reshape(cov, 3npix, 3npix)` away. Since in any practical case the calculation is only going to happen over small subsets of the total, though, it might not actually matter.)