### PR TITLE
Decrease memory requirements in covariance calculations

### DIFF
--- a/src/pixelcovariance.jl
+++ b/src/pixelcovariance.jl
@@ -13,6 +13,8 @@ using StaticArrays
 
 import Base: @propagate_inbounds, checkindex, checkbounds_indices, OneTo, Slice
 
+const PointsVector{T} = AbstractVector{V} where {T, V <: AbstractVector{T}}
+
 module CovarianceFields
     using BitFlags
     export TT, QT, UT, TQ, QQ, UQ, TU, QU, UU, NO_FIELD, TPol, Pol
@@ -295,7 +297,7 @@ end
 #### Pixel-pixel covariance
 ####
 
-function pixelcovariance(pix::AbstractVector, Cl::AbstractMatrix, fields::Field,
+function pixelcovariance(pix::PointsVector, Cl::AbstractMatrix, fields::Field,
                          polconv::Convention = IAUConv)
     T = eltype(first(pix))
     npix = length(pix)
@@ -318,7 +320,7 @@ function pixelcovariance(pix::AbstractVector, Cl::AbstractMatrix, fields::Field,
     return reshape(permutedims(reshape(cov, npix, npix, nr, nc), (1,3,2,4)), nr*npix, nc*npix)
 end
 
-function pixelcovariance!(cov, pix::AbstractVector, pixind, Cl::AbstractMatrix,
+function pixelcovariance!(cov, pix::PointsVector, pixind, Cl::AbstractMatrix,
                           fields::Field, polconv::Convention = IAUConv)
 
     @noinline _chkbounds_throw_scalarorvec(N) = throw(DimensionMismatch(
@@ -372,7 +374,7 @@ end
 Base.eltype(::PixelCovWork{T}) where {T} = T
 
 function unsafe_pixelcovariance!(workornorm::Union{AbstractLegendreNorm,PixelCovWork},
-                                 cov, pix::AbstractVector, pixind, Cl::AbstractMatrix,
+                                 cov, pix::PointsVector, pixind, Cl::AbstractMatrix,
                                  fields::Field, polconv::Convention = IAUConv)
     if workornorm isa AbstractLegendreNorm
         T = promote_type(eltype(workornorm), eltype(cov), eltype(first(pix)))
@@ -386,7 +388,7 @@ function unsafe_pixelcovariance!(workornorm::Union{AbstractLegendreNorm,PixelCov
 end
 
 @propagate_inbounds function _pixelcovariance_impl!(work::PixelCovWork{T},
-        cov, pix::AbstractVector, pixind, Cl::AbstractMatrix, fields::Field,
+        cov, pix::PointsVector, pixind, Cl::AbstractMatrix, fields::Field,
         polconv::Convention) where {T}
 
     F = work.F

--- a/test/sphere.jl
+++ b/test/sphere.jl
@@ -232,3 +232,24 @@ end
 
     @test anal_deriv1(pts) ≈ @inferred dual_deriv1(pts)
 end
+
+@testset "Require 3-vectors" begin
+    vec2a = SVector{2,Float64}(1.0, 0.0)
+    vec2b = SVector{2,Float64}(sqrt(2)/2, sqrt(2)/2)
+    vec4a = SVector{4,Float64}(0.0, 0.0, 0.0, 1.0)
+    vec4b = SVector{4,Float64}(sqrt(2)/2, sqrt(2)/2, 0.0, 0.0)
+
+    @test_throws DimensionMismatch bearing(vec2a, vec2b)
+    @test_throws DimensionMismatch bearing(Vector(vec2a), Vector(vec2b))
+    @test_throws DimensionMismatch bearing2(vec2a, vec2b)
+    @test_throws DimensionMismatch bearing2(Vector(vec2a), Vector(vec2b))
+    @test_throws DimensionMismatch distance(vec2a, vec2b)
+    @test_throws DimensionMismatch distance(Vector(vec2a), Vector(vec2b))
+    @test_throws DimensionMismatch cosdistance(vec2a, vec2b)
+    @test_throws DimensionMismatch cosdistance(Vector(vec2a), Vector(vec2b))
+
+    @test_throws DimensionMismatch reckon(vec2a, π/4, π/2)
+    @test_throws DimensionMismatch reckon(Vector(vec2a), π/4, π/2)
+    @test_throws DimensionMismatch reckon(vec4a, π/4, π/2)
+    @test_throws DimensionMismatch reckon(Vector(vec4a), π/4, π/2)
+end


### PR DESCRIPTION
This PR decreases the memory requirements to calculate covariance matrices which only select a subset of the possible fields. The output array's trailing dimension now only covers the selected sub-blocks rather than all 9 unconditionally (and are covered in ascending bit-field order for the set bits).

The convenience interface `pixelcovariance()` has been updated to make use of this so that it can construct any contiguous set of blocks and have them shaped automatically back into the form of a covariance matrix (rather than the native output format of `pixelcovariance!()`). This means it cannot be used for all possible interesting uses, but since any practical covariance matrix is likely too large to calculate on a single node/at once, this shouldn't be a big hindrance (since real calculations will almost surely use the in-place interface).