### PR TITLE
Initial support for parsing pixelization specifications

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -5,6 +5,7 @@ version = "0.2.4-dev"
 
 [deps]
 BitFlags = "d1d4a3ce-64b1-5f1a-9ba4-7e7e69966f35"
+Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"
 FFTW = "7a1cc6ca-52ef-59f5-83cd-3a7055c09341"
 Legendre = "7642852e-7f09-11e9-134e-0940411082b6"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
@@ -13,6 +14,7 @@ SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 
 [compat]
+Compat = "3.18"
 FFTW = "1"
 Legendre = "0.2.1"
 Reexport = "0.2"

--- a/src/CMB.jl
+++ b/src/CMB.jl
@@ -13,6 +13,9 @@ module CMB
     include("healpix.jl")
     @reexport using .Healpix
 
+    include("pixelizations.jl")
+    @reexport using .Pixelizations
+
     include("pixelcovariance.jl")
     @reexport using .PixelCovariance
 

--- a/src/pixelizations.jl
+++ b/src/pixelizations.jl
@@ -1,0 +1,101 @@
+module Pixelizations
+
+@static if VERSION < v"1.6.0-DEV.1083"
+    using Compat # requires v3.18 for reinterpret(reshape, ...)
+end
+using StaticArrays
+using ..Healpix
+using ..Sphere
+import ..Sphere: latlon, colataz, cartvec
+
+const Vec3{T} = SVector{3,T} where T
+const VecVec3{T} = Vector{V} where {T, V <: Vec3{T}}
+
+abstract type AbstractPixelization end
+
+"""
+    Pixelization
+
+A type used to signal a particular pixelization format, useful for defining dispatch over
+pixelization schemes.
+"""
+struct Pixelization{T} <: AbstractPixelization
+    function Pixelization(name)
+        return new{Symbol(name)}()
+    end
+    function Pixelization{name}() where {name}
+        return new{Symbol(name)}()
+    end
+end
+
+"""
+    pixelization(pix::Pixelization)
+
+Returns the name of the given pixelization as a `Symbol`.
+"""
+pixelization(::Pixelization{T}) where {T} = T
+Base.show(io::IO, pix::Pixelization) = print(io, pixelization(pix), " pixelization")
+
+# Direct interpretation of raw unit vectors
+# pass-through of vectors of SVectors
+Base.parse(::Type{Pixelization}, pixelspec::VecVec3{T}) where {T} = pixelspec
+# convert 3×N matrices into vector of SVectors
+function Base.parse(::Type{Pixelization}, pixelspec::Matrix{T}) where {T}
+    size(pixelspec, 1) == 3 ||
+            throw(DimensionMismatch(string(
+                    "Cannot interpret ", join(string.(size(pixelspec)), "×"),
+                    " matrix as vector of pointing vectors")))
+    if isbitstype(T)
+        return reinterpret(reshape, Vec3{T}, pixelspec)
+    else
+        rvec = similar(Vector{Vec3{T}}, axes(pixelspec, 2))
+        @inbounds for ii in axes(pixelspec, 2)
+            rvec[ii] = Vec3{T}(pixelspec[1,ii], pixelspec[2,ii], pixelspec[3,ii])
+        end
+        return rvec
+    end
+end
+
+# Parsing of dictionary specification into unit vector vectors
+
+# Top-level dispatch mechanism
+"""
+    parse(CMB.Pixelization, pixelspec) -> rvec
+
+Parses a number of recognizable pixelization specifications, returning `rvec`, a vector of
+unit vectors (`Vector{SVector{3,T}} where T`) pointing to pixel centers on the unit sphere.
+"""
+function Base.parse(::Type{Pixelization}, pixelspec::AbstractDict)
+    haskey(pixelspec, "type") || error("pixelization specification identification requires a `\"type\"` field")
+    type = Symbol(pixelspec["type"])
+    rvec = parse(Pixelization(type), pixelspec)
+    return rvec
+end
+
+# HEALPix pixelization
+function Base.parse(::Pixelization{:healpix}, pixelspec::AbstractDict)
+    nside = convert(Int, pixelspec["nside"])::Int
+    if haskey(pixelspec, "pixels")
+        pixind = convert(Vector{Int}, pixelspec["pixels"])::Vector{Int}
+        return pix2vec.(nside, pixind)
+    else
+        pixind = 0:nside2npix(nside)-1
+        return pix2vec.(nside, pixind)
+    end
+end
+
+# RA/Dec pixelizations
+function Base.parse(::Pixelization{:radec}, pixelspec::AbstractDict)
+    radec = pixelspec["pixels"]
+    size(radec, 1) == 2 ||
+            error("Cannot interpret ", join(string.(size(radec)), "×"),
+            " matrix as vector of RA/Dec pairs")
+    T = float(eltype(radec))
+    rvec = similar(Vector{Vec3{T}}, axes(radec, 2))
+    @inbounds for ii in axes(radec, 2)
+        rvec[ii] = cartvec(colataz(radec[2, ii], radec[1, ii]))
+    end
+    return rvec
+end
+
+end

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,4 +1,5 @@
 [deps]
+Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
 InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"

--- a/test/pixelizations.jl
+++ b/test/pixelizations.jl
@@ -1,0 +1,75 @@
+@static if VERSION < v"1.6.0-DEV.1083"
+    using Compat # requires v3.18 for reinterpret(reshape, ...)
+end
+import .Sphere: colataz, cartvec
+import .Pixelizations: Vec3, VecVec3, Pixelization, pixelization
+
+@testset "pixelization types" begin
+    # constructors
+    @test Pixelization("healpix") isa Pixelization{:healpix}
+    @test Pixelization(:healpix) isa Pixelization{:healpix}
+    @test Pixelization{:healpix}() isa Pixelization{:healpix}
+
+    # getting the specific pixelization name
+    @test pixelization(Pixelization(:healpix)) === :healpix
+
+    # pretty-printing of generic pixelizations
+    @test sprint(show, Pixelization(:healpix)) == "healpix pixelization"
+end
+
+@testset "parsing pixelization descriptions" begin
+    @testset "unit vectors ($(float(I)))" for I in (Int, BigInt)
+        T = float(I)
+        # unit vectors on sphere, naturally created as VecVec3
+        rvecs = pix2vec.(I(4), 0:191)
+        @test rvecs isa VecVec3{T}
+        # copy of unit vectors as 3×N matrix
+        rvecs_mat = reduce(hcat, rvecs)
+        @test rvecs_mat isa Matrix{T}
+
+        # pass-through of VecVec3
+        @test @inferred(parse(Pixelization, rvecs)) === rvecs
+
+        # matrices can be reinterpreted as vector of Vec3
+        rvecs_reshape = @inferred(parse(Pixelization, rvecs_mat))
+        @test rvecs_reshape == rvecs
+        @test eltype(rvecs_reshape) <: Vec3{T}
+        wrong_shape = vcat(rvecs_mat, rvecs_mat[1:1,:])
+        @test_throws DimensionMismatch("Cannot interpret 4×192 matrix as vector of pointing vectors"
+                                      ) parse(Pixelization, wrong_shape)
+        @test_throws DimensionMismatch("Cannot interpret 2×192 matrix as vector of pointing vectors"
+                                      ) parse(Pixelization, wrong_shape[1:2, :])
+    end
+
+    @testset "HEALPix" begin
+        nside = 4
+        desc = Dict("type" => "healpix",
+                    "nside" => nside)
+        rvecs = parse(Pixelization, desc)
+        @test rvecs isa VecVec3{Float64}
+        @test rvecs == pix2vec.(nside, 0:nside2npix(nside)-1)
+
+        desc["pixels"] = 0:3nside
+        rvecs = parse(Pixelization, desc)
+        @test rvecs isa VecVec3{Float64}
+        @test rvecs == pix2vec.(nside, 0:3nside)
+    end
+
+    @testset "RA/Dec" begin
+        # low-res BICEP grid
+        nx, ny, res = 236, 100, 4
+        lx, hx, ly, hy = -55.0, 55.0, -70.0, -45.0
+        dx = (hx - lx) / (nx ÷ res)
+        dy = (hy - ly) / (ny ÷ res)
+        ra  = range(lx + dx/2,  hx - dx/2, length=nx÷res)
+        dec = range(ly + dy/2,  hy - dy/2, length=ny÷res)
+        # BICEP's canonical unraveling is as iso-latitude rings
+        radec = copy(reinterpret(reshape, Float64, vec(tuple.(ra, dec'))))
+        desc = Dict("type" => "radec",
+                    "pixels" => radec)
+        rvecs = vec(cartvec.(colataz.(dec', ra)))
+
+        @test radec isa Matrix{Float64}
+        @test parse(Pixelization, desc) == rvecs
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -28,8 +28,9 @@ end
 @testset ExtendedTestSet "CMB" begin
     @include "numerics.jl" "Numerics utilities"
     @include "sphere.jl" "Spherical functions"
-    @include "healpix.jl" "HEALPix functions"
     @include "sphericalharmonics.jl" "Spherical Harmonics"
+    @include "healpix.jl" "HEALPix functions"
+    @include "pixelizations.jl" "Pixelizations"
     @include "pixelcovariance.jl" "Pixel Covariance functions"
     @include "doctests.jl" "Doctests"
 end


### PR DESCRIPTION
Parsing pixelization specifications into unit vectors is necessary for implementing a full, working pipeline for calculating pixel-pixel covariance matrices. This PR is a starting point with minimal levels of functionality — very likely this will have to evolve greatly as more features are required, but the process has to start somewhere. Given this fact, nothing is exported nor is anything documented, which will come later after some time actually using and evolving this part of the code.