### PR TITLE
Make shared conventions types infrastructure

### DIFF
--- a/src/CMB.jl
+++ b/src/CMB.jl
@@ -2,6 +2,7 @@ module CMB
     import Reexport.@reexport
 
     include("numerics.jl")
+    include("conventions.jl")
 
     include("sphere.jl")
     @reexport using .Sphere

--- a/src/conventions.jl
+++ b/src/conventions.jl
@@ -1,0 +1,77 @@
+export PolarizationConventions, StokesCrossFields
+
+module PolarizationConventions
+    export IAUConv, HealpixConv
+
+    """
+        @enum Convention IAUConv HealpixConv
+
+    An enumeration to specify the two types of polarization conventions used to describe
+    Stokes Q/U coordinate systems.
+    """
+    @enum Convention IAUConv HealpixConv
+end
+
+module StokesCrossFields
+    using BitFlags
+    export TT, QT, UT, TQ, QQ, UQ, TU, QU, UU, NO_FIELD, TPol, Pol
+
+    """
+        @bitflag Field TT QT UT TQ QQ UQ TU QU UU NO_FIELD=0
+
+    A bitfield for identifying combinations of Stokes fields. There are 9 subblocks, named
+    as the Cartesian product of elements T, Q, and U:
+
+        TT  TQ  TU
+        QT  QQ  QU
+        UT  UQ  UU
+    """
+    @bitflag Field TT QT UT TQ QQ UQ TU QU UU NO_FIELD=0
+
+    @inline function count_pos(b, i::Int)
+        isset = b & (one(b) << (i - 1)) != zero(b)
+        psum = count_ones(b & ((one(b) << i) - 1))
+        return ifelse(isset, psum, zero(psum))
+    end
+    field_offsets(f::Field) = ntuple(i -> count_pos(Unsigned(f), i), 9)
+    field_count(f::Field) = count_ones(Unsigned(f))
+
+    function minrow(fields::Field)
+        F = Unsigned(fields)
+        f = (F | (F >> 0x3) | (F >> 0x6)) & 0x07
+        return trailing_zeros(f) + 0x1
+    end
+    function maxrow(fields::Field)
+        F = Unsigned(fields)
+        f = (F | (F >> 0x3) | (F >> 0x6)) & 0x07
+        return 8sizeof(F) - leading_zeros(f)
+    end
+
+    function mincol(fields::Field)
+        F = Unsigned(fields)
+        f = (F | (F >> 0x1) | (F >> 0x2)) & 0b001001001 #= 0x49 =#
+        f = (f | (f >> 0x2) | (f >> 0x4)) & 0b111 #= 0x07 =#
+        return trailing_zeros(f) + 0x1
+    end
+    function maxcol(fields::Field)
+        F = Unsigned(fields)
+        f = (F | (F >> 0x1) | (F >> 0x2)) & 0b001001001 #= 0x49 =#
+        f = (f | (f >> 0x2) | (f >> 0x4)) & 0b111 #= 0x07 =#
+        return 8sizeof(F) - leading_zeros(f)
+    end
+
+    """
+        const TPol = QT | UT | TQ | TU
+
+    An alias for the temperature-cross-polarization Stokes field combinations.
+    """
+    const TPol = QT | UT | TQ | TU
+
+    """
+        const Pol  = QQ | UQ | QU | UU
+
+    An alias for the polarization-only sub-blocks Stokes field combinations.
+    """
+    const Pol  = QQ | UQ | QU | UU
+end
+

--- a/src/pixelcovariance.jl
+++ b/src/pixelcovariance.jl
@@ -13,87 +13,13 @@ using StaticArrays
 
 import Base: @propagate_inbounds, checkindex, checkbounds_indices, OneTo, Slice
 
+using ..StokesCrossFields
+using ..StokesCrossFields: Field, field_offsets, field_count, minrow, maxrow, mincol, maxcol
+
+using ..PolarizationConventions
+using ..PolarizationConventions: Convention
+
 const PointsVector{T} = AbstractVector{V} where {T, V <: AbstractVector{T}}
-
-module CovarianceFields
-    using BitFlags
-    export TT, QT, UT, TQ, QQ, UQ, TU, QU, UU, NO_FIELD, TPol, Pol
-
-    """
-        @bitflag Field TT QT UT TQ QQ UQ TU QU UU NO_FIELD=0
-
-    A bitfield for identifying subblocks of the pixel-pixel covariance matrix. There are 9
-    subblocks, named as the Cartesian product of elements T, Q, and U:
-
-        TT  TQ  TU
-        QT  QQ  QU
-        UT  UQ  UU
-    """
-    @bitflag Field TT QT UT TQ QQ UQ TU QU UU NO_FIELD=0
-
-    @inline function count_pos(b, i::Int)
-        isset = b & (one(b) << (i - 1)) != zero(b)
-        psum = count_ones(b & ((one(b) << i) - 1))
-        return ifelse(isset, psum, zero(psum))
-    end
-    field_offsets(f::Field) = ntuple(i -> count_pos(Unsigned(f), i), 9)
-    field_count(f::Field) = count_ones(Unsigned(f))
-
-    function minrow(fields::Field)
-        F = Unsigned(fields)
-        f = (F | (F >> 0x3) | (F >> 0x6)) & 0x07
-        return trailing_zeros(f) + 0x1
-    end
-    function maxrow(fields::Field)
-        F = Unsigned(fields)
-        f = (F | (F >> 0x3) | (F >> 0x6)) & 0x07
-        return 8sizeof(F) - leading_zeros(f)
-    end
-
-    function mincol(fields::Field)
-        F = Unsigned(fields)
-        f = (F | (F >> 0x1) | (F >> 0x2)) & 0b001001001 #= 0x49 =#
-        f = (f | (f >> 0x2) | (f >> 0x4)) & 0b111 #= 0x07 =#
-        return trailing_zeros(f) + 0x1
-    end
-    function maxcol(fields::Field)
-        F = Unsigned(fields)
-        f = (F | (F >> 0x1) | (F >> 0x2)) & 0b001001001 #= 0x49 =#
-        f = (f | (f >> 0x2) | (f >> 0x4)) & 0b111 #= 0x07 =#
-        return 8sizeof(F) - leading_zeros(f)
-    end
-
-    """
-        const TPol = QT | UT | TQ | TU
-
-    An alias for the temperature-cross-polarization sub-blocks of the full covariance
-    matrix.
-    """
-    const TPol = QT | UT | TQ | TU
-
-    """
-        const Pol  = QQ | UQ | QU | UU
-
-    An alias for the polarization-only sub-blocks of the full covariance matrix.
-    """
-    const Pol  = QQ | UQ | QU | UU
-end
-using .CovarianceFields
-using .CovarianceFields: Field, field_offsets, field_count, minrow, maxrow, mincol, maxcol
-
-module PolarizationConventions
-    export IAUConv, HealpixConv
-
-    """
-        @enum Convention IAUConv HealpixConv
-
-    An enumeration to specify the two types of polarization conventions used to describe
-    Stokes Q/U coordinate systems.
-    """
-    @enum Convention IAUConv HealpixConv
-end
-using .PolarizationConventions
-using .PolarizationConventions: Convention
 
 ####
 #### Polarization Weights

--- a/test/conventions.jl
+++ b/test/conventions.jl
@@ -1,0 +1,33 @@
+using .StokesCrossFields
+using .PolarizationConventions
+
+@testset "Stokes bit mask to row/col indexing" begin
+    using .StokesCrossFields: Field, minrow, mincol, maxrow, maxcol,
+            field_count, field_offsets
+
+    # There aren't that many combinations, so just exhaustively check them all.
+    # "Abuse" BitMatrix to interpret the bitfield as a 3x3 matrix, and use reductions
+    # to find the first selected row/column.
+    b = BitMatrix(undef, 3, 3)
+    alltrue = true
+    for ff in 1:(2^9-1)
+        b.chunks[1] = ff
+        alltrue &= minrow(Field(ff)) == findfirst(==(true), dropdims(reduce(|, b, dims = 2), dims = 2))
+        alltrue &= mincol(Field(ff)) == findfirst(==(true), dropdims(reduce(|, b, dims = 1), dims = 1))
+        alltrue &= maxrow(Field(ff)) == findlast(==(true), dropdims(reduce(|, b, dims = 2), dims = 2))
+        alltrue &= maxcol(Field(ff)) == findlast(==(true), dropdims(reduce(|, b, dims = 1), dims = 1))
+    end
+    @test alltrue
+
+    # For performance, we must know that this is properly inferred and optimized by
+    # the compiler. Check that return type matches expectation.
+    @test @inferred(field_offsets(TT)) isa NTuple{9,Int}
+    @test @inferred(field_count(TT)) isa Int
+    @test field_offsets(TT)     == (1, 0, 0, 0, 0, 0, 0, 0, 0)
+    @test field_offsets(Pol)    == (0, 0, 0, 0, 1, 2, 0, 3, 4)
+    @test field_offsets(TT|Pol) == (1, 0, 0, 0, 2, 3, 0, 4, 5)
+    @test field_count(TT) == 1
+    @test field_count(Pol) == 4
+    @test field_count(TT|Pol) == 5
+end
+

--- a/test/conventions.jl
+++ b/test/conventions.jl
@@ -31,3 +31,10 @@ using .PolarizationConventions
     @test field_count(TT|Pol) == 5
 end
 
+@testset "Parsing" begin
+    @test StokesCrossFields.parse("T") == TT
+    @test StokesCrossFields.parse("Q") == QQ
+    @test StokesCrossFields.parse("QU") == Pol
+    @test StokesCrossFields.parse("TQU") == TT | TPol | Pol
+end
+

--- a/test/pixelcovariance.jl
+++ b/test/pixelcovariance.jl
@@ -1,4 +1,3 @@
-using CMB.PixelCovariance
 using LinearAlgebra, Random
 
 # Neither isequal nor == does what exactly we want --- `isequal(NaN, NaN) == true` but
@@ -115,8 +114,8 @@ const nbufs_FweightsWork = 2 + nbufs_LegendreWork # y, xy; x aliased to Legendre
 end
 
 @testset "Pixel-pixel covariance" begin
-    using .PixelCovariance.CovarianceFields
-    using .PixelCovariance.PolarizationConventions
+    using .StokesCrossFields
+    using .PolarizationConventions
 
     nside = 4
     lmax = 3nside - 1
@@ -191,33 +190,6 @@ end
         # Pixel indexing is inbounds
         @test_throws BoundsError pixelcovariance!(cov, pix, -1, Cl, allfields)
         @test_throws BoundsError pixelcovariance!(cov, pix, npix+1, Cl, allfields)
-    end
-
-    @testset "Field mask to row/col indexing" begin
-        using .PixelCovariance.CovarianceFields
-        using .PixelCovariance.CovarianceFields:
-                Field, minrow, mincol, maxrow, maxcol, field_offsets
-
-        # There aren't that many combinations, so just exhaustively check them all.
-        # "Abuse" BitMatrix to interpret the bitfield as a 3x3 matrix, and use reductions
-        # to find the first selected row/column.
-        b = BitMatrix(undef, 3, 3)
-        alltrue = true
-        for ff in 1:(2^9-1)
-            b.chunks[1] = ff
-            alltrue &= minrow(Field(ff)) == findfirst(==(true), dropdims(reduce(|, b, dims = 2), dims = 2))
-            alltrue &= mincol(Field(ff)) == findfirst(==(true), dropdims(reduce(|, b, dims = 1), dims = 1))
-            alltrue &= maxrow(Field(ff)) == findlast(==(true), dropdims(reduce(|, b, dims = 2), dims = 2))
-            alltrue &= maxcol(Field(ff)) == findlast(==(true), dropdims(reduce(|, b, dims = 1), dims = 1))
-        end
-        @test alltrue
-
-        # For performance, we must know that this is properly inferred and optimized by
-        # the compiler. Check that return type matches expectation.
-        @test @inferred(field_offsets(TT)) isa NTuple{9,Int}
-        @test field_offsets(TT)     == (1, 0, 0, 0, 0, 0, 0, 0, 0)
-        @test field_offsets(Pol)    == (0, 0, 0, 0, 1, 2, 0, 3, 4)
-        @test field_offsets(TT|Pol) == (1, 0, 0, 0, 2, 3, 0, 4, 5)
     end
 
     @testset "Field calculations" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -50,6 +50,7 @@ end
 
 @testset ExtendedTestSet "CMB" begin
     @include "numerics.jl" "Numerics utilities"
+    @include "conventions.jl" "Conventions and Definitions"
     @include "sphere.jl" "Spherical functions"
     @include "sphericalharmonics.jl" "Spherical Harmonics"
     @include "healpix.jl" "HEALPix functions"


### PR DESCRIPTION
Calculating the pixel-pixel covariance requires having a certain amount of information about conventions and options exposed to the user, so there were some purpose-built types added in previous PRs. Going forward, though, these are likely to be useful for multiple features, so this PR is moving them to the top-level scope of the module and renaming them to signify that they are more than just as pix-pix-cov helpers.