### PR TITLE
Use cispi from Compat

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -18,7 +18,7 @@ StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 UnixMmap = "674b2976-56af-439b-a2b1-837be4a3d087"
 
 [compat]
-Compat = "3.23"
+Compat = "3.25"
 FFTW = "1"
 FileIO = "1"
 HDF5 = "0.14.0"

--- a/src/healpix.jl
+++ b/src/healpix.jl
@@ -19,7 +19,7 @@ export
     UNSEEN, ishealpixok, checkhealpix, InvalidNside, InvalidPixel
 
 @static if VERSION < v"1.6.0-DEV.292"
-    using Compat # Compat@3.23 for sincospi()
+    import Compat: sincospi # Compat@v3.23
 end
 using Base: @propagate_inbounds
 using StaticArrays

--- a/src/numerics.jl
+++ b/src/numerics.jl
@@ -1,20 +1,5 @@
-@static if VERSION < v"1.6.0-DEV.292"
-    using Compat # Compat@v3.23 for sincospi()
-end
 using SparseArrays
 using SparseArrays: AbstractSparseMatrix
-
-# COV_EXCL_START
-
-# TODO: When JuliaLang/julia#35792 is merged, replace with explicit version bounds
-@static if isdefined(Base, :cispi)
-    using Base: cispi
-else
-    cispi(z::Real) = complex(reverse(sincospi(z))...)
-    cispi(z::Complex) = ((s, c) = sincospi(z); complex(real(c) - imag(s), imag(c) + real(s)))
-end
-
-# COV_EXCL_STOP
 
 # Version of sqrt() which skips the domain (x < 0) check for the IEEE floating point types.
 # For nonstandard number types, just fall back to a regular sqrt() since eliminating the

--- a/src/pixelizations.jl
+++ b/src/pixelizations.jl
@@ -4,7 +4,7 @@ export AbstractPixelization, ArbitraryPixelization, HealpixPixelization, RADecPi
        parse_pixelization, export_pixelization, pointing
 
 @static if VERSION < v"1.6.0-DEV.1083"
-    using Compat # Compat@v3.18 for reinterpret(reshape, ...)
+    import Compat # Compat@v3.18 for reinterpret(reshape, ...)
 end
 using StaticArrays
 using ..Healpix

--- a/src/sphericalharmonics.jl
+++ b/src/sphericalharmonics.jl
@@ -6,7 +6,9 @@ module SphericalHarmonics
 using ..Legendre
 using FFTW
 using LinearAlgebra: mul!
-import ..cispi
+@static if VERSION < v"1.6.0-DEV.1591"
+    using Compat: cispi # Compat@v3.25
+end
 
 function centered_range(start, stop, length)
     rng = range(start, stop, length=length+1)

--- a/test/pixelizations.jl
+++ b/test/pixelizations.jl
@@ -1,5 +1,5 @@
 @static if VERSION < v"1.6.0-DEV.1083"
-    using Compat # requires v3.18 for reinterpret(reshape, ...)
+    import Compat # requires v3.18 for reinterpret(reshape, ...)
 end
 import .Sphere: colataz, cartvec
 import .Pixelizations: Vec3

--- a/test/pixelizations.jl
+++ b/test/pixelizations.jl
@@ -1,5 +1,8 @@
+@static if VERSION < v"1.5.0-DEV.639"
+    import Compat: contains # Compat@v3.15
+end
 @static if VERSION < v"1.6.0-DEV.1083"
-    import Compat # requires v3.18 for reinterpret(reshape, ...)
+    import Compat # Compat@v3.18 for reinterpret(reshape, ...)
 end
 import .Sphere: colataz, cartvec
 import .Pixelizations: Vec3


### PR DESCRIPTION
With https://github.com/JuliaLang/Compat.jl/pull/732 merged, use `cispi` from `Compat` rather than a self-provided implementation.