### PR TITLE
Bump compat to include HDF5 v0.15, StaticArrays v1, Reexport v1

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "CMB"
 uuid = "592991c5-7c29-5f04-aea2-6d9f924ef2a1"
 author = ["Justin Willmert <justin@willmert.me>"]
-version = "0.2.5-dev"
+version = "0.2.5"
 
 [deps]
 BitFlags = "d1d4a3ce-64b1-5f1a-9ba4-7e7e69966f35"
@@ -18,14 +18,15 @@ StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 UnixMmap = "674b2976-56af-439b-a2b1-837be4a3d087"
 
 [compat]
+BitFlags = "0.1"
 Compat = "3.25"
 FFTW = "1"
 FileIO = "1"
-HDF5 = "0.14.0"
+HDF5 = "0.14, 0.15"
 Legendre = "0.2.1"
-Reexport = "0.2"
+Reexport = "0.2, 1"
 Requires = "1"
-StaticArrays = "0.11, 0.12"
+StaticArrays = "0.11, 0.12, 1"
 UnixMmap = "0.1"
 julia = "1.3"
 

--- a/src/fileio.jl
+++ b/src/fileio.jl
@@ -46,8 +46,8 @@ See [`write_obsmat`](@ref) for writing a native HDF5 file to disk.
 Importing observing matrices from the following additional data formats is supported
 via `Requires.jl`, which requires the user to first load the extra backend of choice.
 
-- `JLD` and `JLD2`-flavored HDF5 files with `JLD.jl` and `JLD2.jl`, respectively.
-- MATLAB v5, v6, v7, and v7.3 save files with `MAT.jl`.
+- `JLD` and `JLD2`-flavored HDF5 files with `JLD.jl` (v0.12+) and `JLD2.jl`, respectively.
+- MATLAB v5, v6, v7, and v7.3 save files with `MAT.jl` (v0.10+).
 - `scipy.sparse` CSC and CSR matrices saved to HDF5 files with `h5sparse`. This case
   is supported without needing to load any extra packages.
 
@@ -85,14 +85,14 @@ function __init__()
             hid = JLD.jldopen(FileIO.filename(file))
             @inline function _missing_read(name)
                 name === nothing && return missing
-                !exists(hid, name) && return missing
+                !haskey(hid, name) && return missing
                 return read(hid[name])
             end
             try
                 if name === nothing
                     R = missing
                 else
-                    !exists(hid, name) && error("Error reading /", name)
+                    !haskey(hid, name) && error("Error reading /", name)
                     R = read(hid, name)
                 end
                 metadata = (;
@@ -178,14 +178,14 @@ function __init__()
             hid = matopen(FileIO.filename(file))
             @inline function _missing_read(name)
                 name === nothing && return missing
-                !exists(hid, name) && return missing
+                !haskey(hid, name) && return missing
                 return read(hid, name)
             end
             try
                 if name === nothing
                     R = missing
                 else
-                    !exists(hid, name) && error("Error reading /", name)
+                    !haskey(hid, name) && error("Error reading /", name)
                     R = read(hid, name)
                 end
                 fields = _missing_read(fields)

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -18,3 +18,5 @@ TestSetExtensions = "98d24dd4-01ad-11ea-1b02-c9a08f80db04"
 
 [compat]
 Documenter = "~0.24.0"
+JLD = "0.12"
+MAT = "0.10"


### PR DESCRIPTION
- Explicitly include BitFlags at v0.1 compatible
- Tests now require MAT v0.10, JLD v0.12

closes #52, closes #53, closes #54, closes #55