### PR TITLE
Follow rename Legendre -> AssociatedLegendrePolynomials

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,13 +49,8 @@ jobs:
             ${{ runner.os }}-test-${{ env.cache-name }}-
             ${{ runner.os }}-test-
             ${{ runner.os }}-
-      - name: Add private Registry
-        run: |
-          julia --project -e '
-            using Pkg
-            Registry.add(RegistrySpec("General"))
-            Registry.add(RegistrySpec(url = "https://github.com/jmert/Registry.jl"))
-            include("scripts/test_minver.jl")'
+      - name: Setup package versions
+        run: julia --project scripts/test_minver.jl
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
       - uses: julia-actions/julia-processcoverage@v1
@@ -70,13 +65,6 @@ jobs:
       - uses: julia-actions/setup-julia@v1
         with:
           version: '1'
-      - name: Add private Registry
-        run: |
-          julia --project -e '
-            using Pkg
-            Registry.add(RegistrySpec("General"))
-            Registry.add(RegistrySpec(url = "https://github.com/jmert/Registry.jl"))
-            include("scripts/test_minver.jl")'
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-docdeploy@v1
         env:

--- a/Project.toml
+++ b/Project.toml
@@ -1,15 +1,15 @@
 name = "CMB"
 uuid = "592991c5-7c29-5f04-aea2-6d9f924ef2a1"
 author = ["Justin Willmert <justin@willmert.me>"]
-version = "0.2.5"
+version = "0.3.0"
 
 [deps]
+AssociatedLegendrePolynomials = "2119f1ac-fb78-50f5-8cc0-dda848ebdb19"
 BitFlags = "d1d4a3ce-64b1-5f1a-9ba4-7e7e69966f35"
 Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"
 FFTW = "7a1cc6ca-52ef-59f5-83cd-3a7055c09341"
 FileIO = "5789e2e9-d7fb-5bc7-8068-2c6fae9b9549"
 HDF5 = "f67ccb44-e63f-5c2f-98bd-6dc0ccc4ba2f"
-Legendre = "7642852e-7f09-11e9-134e-0940411082b6"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
 Requires = "ae029012-a4dd-5104-9daa-d747884805df"
@@ -18,16 +18,16 @@ StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 UnixMmap = "674b2976-56af-439b-a2b1-837be4a3d087"
 
 [compat]
+AssociatedLegendrePolynomials = "1"
 BitFlags = "0.1"
 Compat = "3.25"
 FFTW = "1"
 FileIO = "1"
 HDF5 = "0.14, 0.15"
-Legendre = "0.2.1"
 Reexport = "0.2, 1"
 Requires = "1"
 StaticArrays = "0.11, 0.12, 1"
-UnixMmap = "0.1, 1"
+UnixMmap = "1"
 julia = "1.3"
 
 [extras]

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -7,4 +7,4 @@ JLD2 = "033835bb-8acc-5ee8-8aae-3f567f8a3819"
 MAT = "23992714-dd62-5051-b70f-ba57cb901cac"
 
 [compat]
-Documenter = "0.25.2"
+Documenter = "0.25.2, 0.26, 0.27"

--- a/docs/src/man/pixelcov.md
+++ b/docs/src/man/pixelcov.md
@@ -71,7 +71,7 @@ In this simplified case, the 6 unique covariances are
 for ``z_{ij} = \cos(\sigma_{ij})`` and some fiducial spectrum ``C_\ell``.
 The polarization weighting functions are simple functions of the ``P_\ell`` and
 ``P_\ell^2``
-[associated Legendre polynomials](https://jmert.github.io/Legendre.jl/stable/),
+[associated Legendre polynomials](https://jmert.github.io/AssociatedLegendrePolynomials.jl/stable/),
 ```math
 \begin{align}
     \covF{00} &\equiv (2\ell + 1) P_\ell(z_{ij})

--- a/docs/src/man/sphere.md
+++ b/docs/src/man/sphere.md
@@ -76,8 +76,8 @@ julia> σ = distance(r₁, r₂)
 1.6187031137492613
 ```
 In situations where the cosine of the separation is required instead — such
-as for [Legendre polynomial](https://github.com/jmert/Legendre.jl) calculations
-— it is more efficient to directly return the cosine of the angle with the
+as for [Legendre polynomial](https://github.com/jmert/AssociatedLegendrePolynomials.jl)
+calculations — it is more efficient to directly return the cosine of the angle with the
 [`cosdistance`](@ref) function:
 ```jldoctest sphereusage
 julia> cosdistance(r₁, r₂)

--- a/examples/square_pixel_window_function/notebook.ipynb
+++ b/examples/square_pixel_window_function/notebook.ipynb
@@ -273,7 +273,7 @@
     "need to calculate the legendre polynomials at particular values of $z$\n",
     "on demand.\n",
     "\n",
-    "The `Legendre` package (reexported from the `CMB.Legendre` module) provides\n",
+    "The `AssociatedLegendrePolynomials` package (reexported as `CMB.Legendre`) provides\n",
     "the `legendre()`-family of functions.\n",
     "Because the polynomials are computed via recursion relations over $\\ell$\n",
     "and $m$, it is most efficient to compute all degrees and orders\n",

--- a/src/CMB.jl
+++ b/src/CMB.jl
@@ -1,5 +1,6 @@
 module CMB
     import Reexport.@reexport
+    import Compat.@compat # Compat@v3.21 for @compat import Mod as NewName
 
     include("numerics.jl")
     include("conventions.jl")
@@ -7,7 +8,10 @@ module CMB
     include("sphere.jl")
     @reexport using .Sphere
 
-    @reexport using Legendre
+    @compat import AssociatedLegendrePolynomials as Legendre
+    @reexport using .Legendre
+    export Legendre
+
     include("sphericalharmonics.jl")
     @reexport using .SphericalHarmonics
 

--- a/src/pixelcovariance.jl
+++ b/src/pixelcovariance.jl
@@ -7,8 +7,8 @@ import ..Sphere: bearing2, cosdistance
 import ..Healpix: pix2vec
 import ..unchecked_sqrt
 
-using Legendre
-using Legendre: unsafe_legendre!
+import ..Legendre
+using ..Legendre
 using StaticArrays
 
 import Base: @propagate_inbounds, checkindex, checkbounds_indices, OneTo, Slice
@@ -140,7 +140,7 @@ end
     fill!(@view(F[Is..., OneTo(2), :]), zero(T))
 
     # Fill with the P^2_ℓ(x) terms initially
-    unsafe_legendre!(legwork, P, lmax, 2, x)
+    Legendre.unsafe_legendre!(legwork, P, lmax, 2, x)
     # Calculate the F12 and F22 terms using P^2_ℓ
     for ll in 2:lmax
         η = coeff_η(T, ll)
@@ -175,7 +175,7 @@ end
         end
     end
     # Replace with P^0_ℓ(x) terms
-    unsafe_legendre!(legwork, P, lmax, 0, x)
+    Legendre.unsafe_legendre!(legwork, P, lmax, 0, x)
     # Then calculate the F10 terms
     for ll in 2:lmax
         lm1 = convert(T, ll) - one(T)

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -17,6 +17,6 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 TestSetExtensions = "98d24dd4-01ad-11ea-1b02-c9a08f80db04"
 
 [compat]
-Documenter = "~0.24.0"
+Documenter = "0.25.2, 0.26, 0.27"
 JLD = "0.12"
 MAT = "0.10"


### PR DESCRIPTION
Legendre.jl is proposing to be renamed to LegendrePolynomials.jl in https://github.com/jmert/Legendre.jl/pull/30 (as a step to becoming a registered package in the General registry) — this PR tracks that change.

- [x] AssociatedLegendrePolynomials.jl needs to be registered before tests will pass.