### PR TITLE
Fix allocation in pixelcovariance! with pre-allocated work space

### DIFF
--- a/src/pixelcovariance.jl
+++ b/src/pixelcovariance.jl
@@ -284,9 +284,9 @@ function pixelcovariance!(cov, pix::PointsVector, pixind, Cl::AbstractMatrix,
     return unsafe_pixelcovariance!(LegendreUnitNorm(), cov, pix, pixind, Cl, fields, polconv)
 end
 
-struct PixelCovWork{T,N,V}
+struct PixelCovWork{T,W<:FweightsWork{T}}
     F::Matrix{T}
-    Fwork::FweightsWork{T,N,V}
+    Fwork::W
 end
 function PixelCovWork{T}(lmax::Int, norm::AbstractLegendreNorm = LegendreUnitNorm()) where {T}
     F = Matrix{T}(undef, lmax+1, 4)

--- a/test/pixelcovariance.jl
+++ b/test/pixelcovariance.jl
@@ -214,15 +214,12 @@ end
         # Check equality before allocations to ensure the methods have been compiled.
         @test unsafe_pixelcovariance!(norm, copy(cov), pix, pixind, Cl, allfields) ==
                 unsafe_pixelcovariance!(work, cov, pix, pixind, Cl, allfields)
-
         # Lower bound on allocations required
         nb  = sizeof(eltype(first(pix))) * nbufs_FweightsWork
         nb += sizeof(eltype(first(pix))) * 4 * (lmax + 1)
         @test nb <= @allocated unsafe_pixelcovariance!(norm, cov, pix, pixind, Cl, allfields)
-
-        # Currently broken, even on v1.5 --- haven't figured out where the allocations are
-        # happening
-        @test_broken nb > @allocated unsafe_pixelcovariance!(work, cov, pix, pixind, Cl, allfields)
+        # Pre-allocated version doesn't allocate
+        @test 0 == @allocated unsafe_pixelcovariance!(work, cov, pix, pixind, Cl, allfields)
     end
 
     @testset "Positive-definite covariance" begin


### PR DESCRIPTION
The type constraint on the `FweightsWork` field within the
`PixelCovWork` struct was missing a type parameter, and therefore it
was constrained to be an abstract type.

Rather than adding another type parameter for the 4th param explicitly,
instead just switch to allowing the type system to choose the explicit
type of the field and just constrain it to be some kind of
`FweightsWork`.

Fixes the one broken test which was recognizing that the design should
have meant that the pixel covariance kernel is allocation-free if given
pre-allocated work space, but it wasn't.