### PR TITLE
Fix type promotion error in vec2pix

### DIFF
--- a/src/healpix.jl
+++ b/src/healpix.jl
@@ -507,7 +507,7 @@ Like [`vec2pix`](@ref) but does not check the validity of the `nside` or length 
     z = r[3]
     ϕ = atan(r[2], r[1])
     ϕ += ifelse(ϕ < zero(ϕ), 2oftype(ϕ, π), zero(ϕ))
-    return unsafe_zphi2pix(nside, z, ϕ)
+    return unsafe_zphi2pix(nside, promote(z, ϕ)...)
 end
 
 """

--- a/test/healpix.jl
+++ b/test/healpix.jl
@@ -182,8 +182,9 @@ end
         @test fn(4, BigInt(0)) == fn(BigInt(4), BigInt(0))
         @test fn(BigInt(4), 0) == fn(BigInt(4), BigInt(0))
     end
-    @test ang2pix(4, 1f0, 1e0) == ang2pix(4, 1e0, 1e0)
-    @test ang2pix(4, 1e0, 1f0) == ang2pix(4, 1e0, 1e0)
+    @test ang2pix(4, 1f0, 1e0) === ang2pix(4, 1e0, 1e0)
+    @test ang2pix(4, 1e0, 1f0) === ang2pix(4, 1e0, 1e0)
+    @test vec2pix(4, Int[1, 0, 0]) === vec2pix(4, Float64[1, 0, 0])
 end
 
 @testset "Accuracy of pix2vec" begin


### PR DESCRIPTION
An integer pointing vector (such as `CMB.Sphere.x̂`) would pass along
mixed types to the internal function, which assumes uniform angle
arguments. Fix the promotion error, and add a test to recognize this
case.