### PR TITLE
Import StaticArrays.SVector into docs to have type-only printing

### DIFF
--- a/docs/src/man/healpix.md
+++ b/docs/src/man/healpix.md
@@ -170,9 +170,9 @@ julia> pix2ang(nside, 103) .|> rad2deg
 The other common way to represent coordinates on the sphere is via unit vectors.
 The corresponding vector for a given pixel is retrieved with
 [`CMB.Healpix.pix2vec`](@ref).
-```jldoctest healpix
+```jldoctest healpix; setup = (import StaticArrays: SVector)
 julia> pix2vec(nside, 103)
-3-element StaticArrays.SVector{3, Float64} with indices SOneTo(3):
+3-element SVector{3, Float64} with indices SOneTo(3):
   0.9807852804032304
  -0.19509032201612828
   0.0

--- a/docs/src/man/sphere.md
+++ b/docs/src/man/sphere.md
@@ -38,7 +38,7 @@ and unit vectors can be accomplished via the unexported functions
 [`Sphere.colataz`](@ref), [`Sphere.latlon`](@ref), and
 [`Sphere.cartvec`](@ref).
 
-```jldoctest sphereusage
+```jldoctest sphereusage; setup = (import StaticArrays.SVector)
 julia> using CMB.Sphere
 
 julia> using CMB.Sphere: colataz, latlon, cartvec
@@ -52,7 +52,7 @@ julia> latlon(θ, ϕ)                 # colat-az to lat-lon
 (44.97531, -93.23471)
 
 julia> r = cartvec(θ, ϕ)            # colat-az to unit vector
-3-element StaticArrays.SVector{3, Float64} with indices SOneTo(3):
+3-element SVector{3, Float64} with indices SOneTo(3):
  -0.03991664732478908
  -0.7062843499648845
   0.7068020078218715
@@ -143,7 +143,7 @@ Given the angular distance `σ` and bearing `α₁` from before, we can reconstr
 julia> using LinearAlgebra: dot
 
 julia> reckon(r₁, σ, α₁)
-3-element StaticArrays.SVector{3, Float64} with indices SOneTo(3):
+3-element SVector{3, Float64} with indices SOneTo(3):
  0.3289121239720345
  0.11296169792358199
  0.937580113647056

--- a/src/sphere.jl
+++ b/src/sphere.jl
@@ -321,9 +321,9 @@ The point on the sphere is given as a unit vector ``r``.
 
     For example, moving a distance ``π/2`` with no bearing goes to the negative ``x``
     axis (i.e. 0° N, 180° W):
-    ```jldoctest
+    ```jldoctest; setup = (import StaticArrays.SVector)
     julia> reckon([0.0, 0.0, 1.0], π/2, 0.0)
-    3-element StaticArrays.SVector{3, Float64} with indices SOneTo(3):
+    3-element SVector{3, Float64} with indices SOneTo(3):
      -1.0
       0.0
       6.123233995736766e-17


### PR DESCRIPTION
This avoids a doctest failures from mismatched owner modules depending
on the version of StaticArrays which is loaded. For StaticArrays < v1.5,
the fully-qualified type is `StaticArrays.SVector`, but starting with
v1.5 the type definition moved to `StaticArraysCore.SVector`.
    
By importing explicitly from StaticArrays into the environment, the
printing system skips the module component and therefore we don't see
any discrepancy in printing no matter which version of
Julia + StaticArrays is being used.